### PR TITLE
Minor logging fixes

### DIFF
--- a/lib/cache_fs.js
+++ b/lib/cache_fs.js
@@ -54,14 +54,16 @@ class CacheFS {
         if (fix) {
             try {
                 var stat = fs.statSync(path);
-                if (stat.isDirectory())
+                if (stat.isDirectory()) {
                     fs.rmdirSync(path);
-                else
+                    helpers.log(consts.LOG_DBG, msg + " Directory deleted.");
+                } else {
                     fs.unlinkSync(path);
-                helpers.log(consts.LOG_DBG, msg + " File deleted.");
+                    helpers.log(consts.LOG_DBG, msg + " File deleted.");
+                }
             }
             catch (err) {
-                helpers.log(consts.LOG_DBG, err);
+                helpers.log(consts.LOG_ERR, err);
             }
         }
         else {


### PR DESCRIPTION
Minor fixes to debug logging when a file or directory is removed; fix a spot where an error was logged to DBG instead of ERR