### PR TITLE
Travis: Test on Node 8 (LTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - "6"
+  - "8"
 after_success:
 - npm run coveralls


### PR DESCRIPTION
Test cache-server on Node.js 8.x (ATM latest LTS release).