### PR TITLE
Remove extranous defaults in help output

### DIFF
--- a/main.js
+++ b/main.js
@@ -29,12 +29,12 @@ const defaultCacheModule = config.get("Cache.defaultModule");
 
 program.description("Unity Cache Server")
     .version(VERSION)
-    .option('-p, --port <n>', `Specify the server port, only apply to new cache server, default is ${consts.DEFAULT_PORT}`, myParseInt, consts.DEFAULT_PORT)
-    .option('-c --cache-module [path]', `Use cache module at specified path. Default is '${defaultCacheModule}'`, defaultCacheModule)
-    .option('-P, --cache-path [path]', `Specify the path of the cache directory`)
-    .option('-l, --log-level <n>', `Specify the level of log verbosity. Valid values are 0 (silent) through 5 (debug). Default is ${consts.DEFAULT_LOG_LEVEL}`, myParseInt, consts.DEFAULT_LOG_LEVEL)
-    .option('-w, --workers <n>', `Number of worker threads to spawn. Default is ${consts.DEFAULT_WORKERS}`, zeroOrMore, consts.DEFAULT_WORKERS)
-    .option('-m --mirror [host:port]', `Mirror transactions to another cache server. Can be repeated for multiple mirrors`, collect, [])
+    .option('-p, --port <n>', 'Specify the server port, only apply to new cache server', myParseInt, consts.DEFAULT_PORT)
+    .option('-c --cache-module [path]', 'Use cache module at specified path', defaultCacheModule)
+    .option('-P, --cache-path [path]', 'Specify the path of the cache directory')
+    .option('-l, --log-level <n>', 'Specify the level of log verbosity. Valid values are 0 (silent) through 5 (debug)', myParseInt, consts.DEFAULT_LOG_LEVEL)
+    .option('-w, --workers <n>', 'Number of worker threads to spawn', zeroOrMore, consts.DEFAULT_WORKERS)
+    .option('-m --mirror [host:port]', 'Mirror transactions to another cache server. Can be repeated for multiple mirrors', collect, [])
     .option('-m, --monitor-parent-process <n>', 'Monitor a parent process and exit if it dies', myParseInt, 0);
 
 program.parse(process.argv);


### PR DESCRIPTION
De-duplicates display of defaults. From ex. 

    Specify the server port, only apply to new cache server, default is 8126 (default: 8126)

to

    Specify the server port, only apply to new cache server (default: 8126)