### PR TITLE
[pr] Feature/high reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ This open-source repository is maintained separately from the Cache Server avail
   * [cache\_ram](#cache_ram)
 * [Cache Cleanup](#cache-cleanup)
 * [Mirroring](#mirroring)
+* [High Reliability Mode](#high-reliability-mode)
+  * [Background](#background)
+  * [Function](#function)
+  * [Configuration](#configuration)
 * [Unity project Library Importer](#unity-project-library-importer)
 * [Contributors](#contributors)
 * [License](#license)
@@ -185,6 +189,31 @@ Option                | Default     | Description
 --------------------- | ----------- | -----------
 queueProcessDelay     | 2000        | The period, in milliseconds, to delay the start of processing the queue, from when the first transaction is added to an empty queue. Each transaction from a client is queued after completion. It's a good idea to keep this value at or above the default value to avoid possible I/O race conditions with recently completed transactions.
 connectionIdleTimeout | 10000       | The period, in milliseconds, to keep connections to remote mirror hosts alive, after processing a queue of transactions. Queue processing is bursty. To minimize the overhead of connection setup and teardown, calibrate this value for your environment.
+
+## High Reliability Mode
+
+High Reliability Mode increases the integrity of cached data by introducing stricter requirements on upload transactions.
+
+### Background
+
+Asset versions are cached based on the asset GUID and hash reported by the client (Unity). The asset hash is a calculation of _inputs_ to the asset import process. Ideally, the import process produces the same binary result for a given asset hash, but there is no guarantee. In some cases an instability in the import process is harmless, but often this is an indication of a bug or an asset importer design problem. These errors can be propagated to other clients because Unity is not able to detect these instabilities before committing them to the Cache Server.
+
+### Function
+
+In the default operating mode (highReliability = `false`), the Cache Server accepts all transactions for all versions from any Unity client. This means that versions can possibly change after they are already committed, and that the committed data may or may not represent a correct, stable import. High Reliability Mode allows the Cache Server to compare multiple transactions for the same version for binary stability before committing a version to the cache, and disallows further modifications to already committed versions. When an instability is detected, warning messages are logged and the asset will no longer be cached until a version with a new hash is uploaded.
+
+Given the higher cost of requiring multiple imports of the same asset to ensure the stability of each asset version, High Reliability Mode is mostly beneficial to developers in networked team environments, especially as the team grows and the overall cost can be distributed to a larger number of client systems.
+
+### Configuration
+
+When highReliability is `true`, a _reliabilityFactor_ for an asset version is incremented with each transaction that is binary identical to the previous. When the _reliabilityFactor_ meets the configured _reliabilityThreshold_, the version will be committed to the cache and served. For networked team environments, setting `multiClient` to `true` will force more than one client to commit the same transaction in order to increment the _reliabilityFactor_. Note that a value of 0 or 1 for `reliabilityThreshold` will effectively disable the reliability checks, but still prevent versions from changing. For debugging purposes, setting `saveUnreliableVersionArtifacts` to `true` will isolate and save all uploads of unstable asset versions for later inspection and diffing.
+
+Option                                               | Default      | Description
+------------------------------------------           | ------------ | -----------
+highReliability                                      | false        | Enable high reliability mode
+highReliabilityOptions.reliabilityThreshold          | 2            | Number of binary-stable imports of the same version required before a version will be cached and served
+highReliabilityOptions.saveUnreliableVersionArtifacts| true         | After a version is declared unreliable, save all subsequent transactions for the version for later inspection and debugging
+highReliabilityOptions.multiClient                   | false        | Require multiple clients to upload the same binary-stable version in order to increment the stability factor. i.e. if the same client uploads the same version twice in a row, it will not increase stability of the version.
 
 ## Unity project Library Importer
 

--- a/README.md
+++ b/README.md
@@ -192,30 +192,31 @@ connectionIdleTimeout | 10000       | The period, in milliseconds, to keep conne
 
 ## High Reliability Mode
 
-High Reliability Mode increases the integrity of cached data by introducing stricter requirements on upload transactions.
+High Reliability Mode imposes stricter requirements on upload transactions to increase the integrity of cached data.
 
 ### Background
 
-Asset versions are cached based on the asset GUID and hash reported by the client (Unity). The asset hash is a calculation of _inputs_ to the asset import process. Ideally, the import process produces the same binary result for a given asset hash, but there is no guarantee. In some cases an instability in the import process is harmless, but often this is an indication of a bug or an asset importer design problem. These errors can be propagated to other clients because Unity is not able to detect these instabilities before committing them to the Cache Server.
+Asset versions are cached based on the Asset GUID and Asset hash reported by the client (Unity Editor). The Asset hash is calculated from the inputs to the Asset import process. The import process should produce the same binary result for a given set of inputs, but there is no guarantee that it will. Instability in the import process is typically an indication of a bug or design problem in the Asset importer.These errors can be propagated to other clients because Unity is not able to detect these instabilities before committing them to the Cache Server.
 
 ### Function
 
-In the default operating mode (`highReliability` is `false`), the Cache Server accepts all transactions for all versions from any Unity client. This means that versions can possibly change after they are already committed, and that the committed data may or may not represent a correct, stable import. In team environments especially, it would be preferable to forgo caching of the particular asset version and allow other Unity clients to import the asset through the normal import pipeline.
+In the default operating mode (`highReliability` is __false__), the Cache Server accepts all transactions for all versions of an Asset from any Unity client. In this scenario, the version of an Asset can change after it is already committed and the commit can cause an incorrect or unstable import.
 
-High Reliability Mode allows the Cache Server to compare multiple transactions for the same version for binary stability before committing a version to the cache, and disallows further modifications to already committed versions. When an instability is detected, warning messages are logged and the asset will no longer be cached until a version with a new hash is uploaded.
+High Reliability Mode allows the Cache Server to compare multiple transactions for the same version for binary stability before committing a version to the cache, and disallows further modifications to already committed versions. When an instability is detected, warning messages are logged and caching of the Asset is suspended until a team member uploads a new version of the Asset.
 
-Given the higher cost of requiring multiple imports of the same asset to ensure the stability of each asset version, High Reliability Mode is mostly beneficial to developers in networked team environments, especially as the team grows and the overall cost can be distributed to a larger number of client systems.
+Requiring multiple imports of the same Asset to ensure the stability of each Asset version is resource intensive. High Reliability Mode is primarily beneficial to developers in networked team environments, where the increased overhead of importing Assets multiple times is distributed across the entire team. The larger the team, the smaller the impact on any individual.
+
 
 ### Configuration
 
-When `highReliability` is `true`, a _reliabilityFactor_ for an asset version is incremented with each transaction that is binary identical to the previous. When the _reliabilityFactor_ meets the configured _reliabilityThreshold_, the version will be committed to the cache and served. For networked team environments, setting `multiClient` to `true` will force more than one client to commit the same transaction in order to increment the _reliabilityFactor_. Note that a value of 0 or 1 for `reliabilityThreshold` will effectively disable the reliability checks, but still prevent versions from changing. For debugging purposes, setting `saveUnreliableVersionArtifacts` to `true` will isolate and save all uploads of unstable asset versions for later inspection and diffing.
+When _highReliability_ is __true__, a counter for an Asset version is incremented with each transaction that is binary identical to the previous. When the counter reaches the configured `reliabilityThreshold`, the version is committed to the cache and served. For networked team environments, setting `multiClient` to __true__ forces more than one client to commit the same transaction to increment the counter. Setting `reliabilityThreshold` to  a value of 0 or 1 disables the reliability checks, but still prevents versions from changing. For debugging purposes, setting `saveUnreliableVersionArtifacts` to __true__ isolates and saves all uploads of unstable Asset versions for later inspection and diffing.
 
 Option                                               | Default      | Description
 ------------------------------------------           | ------------ | -----------
-highReliability                                      | false        | Enable high reliability mode
-highReliabilityOptions.reliabilityThreshold          | 2            | Number of binary-stable imports of the same version required before a version will be cached and served
-highReliabilityOptions.saveUnreliableVersionArtifacts| true         | After a version is declared unreliable, save all subsequent transactions for the version for later inspection and debugging
-highReliabilityOptions.multiClient                   | false        | Require multiple clients to upload the same binary-stable version in order to increment the stability factor. i.e. if the same client uploads the same version twice in a row, it will not increase stability of the version
+highReliability                                      | false        | Enable high reliability mode.
+highReliabilityOptions.reliabilityThreshold          | 2            | Number of binary-stable imports of the same version required before a version is cached and served.
+highReliabilityOptions.saveUnreliableVersionArtifacts| true         | After a version is declared unreliable, save all subsequent transactions for the version for later inspection and debugging.
+highReliabilityOptions.multiClient                   | false        | Require multiple clients to upload the same binary-stable version to increment the stability factor. For example, if the same client uploads the same version twice in a row, it does not increase stability of the version.
 
 ## Unity project Library Importer
 

--- a/README.md
+++ b/README.md
@@ -200,20 +200,22 @@ Asset versions are cached based on the asset GUID and hash reported by the clien
 
 ### Function
 
-In the default operating mode (highReliability = `false`), the Cache Server accepts all transactions for all versions from any Unity client. This means that versions can possibly change after they are already committed, and that the committed data may or may not represent a correct, stable import. High Reliability Mode allows the Cache Server to compare multiple transactions for the same version for binary stability before committing a version to the cache, and disallows further modifications to already committed versions. When an instability is detected, warning messages are logged and the asset will no longer be cached until a version with a new hash is uploaded.
+In the default operating mode (`highReliability` is `false`), the Cache Server accepts all transactions for all versions from any Unity client. This means that versions can possibly change after they are already committed, and that the committed data may or may not represent a correct, stable import. In team environments especially, it would be preferable to forgo caching of the particular asset version and allow other Unity clients to import the asset through the normal import pipeline.
+
+High Reliability Mode allows the Cache Server to compare multiple transactions for the same version for binary stability before committing a version to the cache, and disallows further modifications to already committed versions. When an instability is detected, warning messages are logged and the asset will no longer be cached until a version with a new hash is uploaded.
 
 Given the higher cost of requiring multiple imports of the same asset to ensure the stability of each asset version, High Reliability Mode is mostly beneficial to developers in networked team environments, especially as the team grows and the overall cost can be distributed to a larger number of client systems.
 
 ### Configuration
 
-When highReliability is `true`, a _reliabilityFactor_ for an asset version is incremented with each transaction that is binary identical to the previous. When the _reliabilityFactor_ meets the configured _reliabilityThreshold_, the version will be committed to the cache and served. For networked team environments, setting `multiClient` to `true` will force more than one client to commit the same transaction in order to increment the _reliabilityFactor_. Note that a value of 0 or 1 for `reliabilityThreshold` will effectively disable the reliability checks, but still prevent versions from changing. For debugging purposes, setting `saveUnreliableVersionArtifacts` to `true` will isolate and save all uploads of unstable asset versions for later inspection and diffing.
+When `highReliability` is `true`, a _reliabilityFactor_ for an asset version is incremented with each transaction that is binary identical to the previous. When the _reliabilityFactor_ meets the configured _reliabilityThreshold_, the version will be committed to the cache and served. For networked team environments, setting `multiClient` to `true` will force more than one client to commit the same transaction in order to increment the _reliabilityFactor_. Note that a value of 0 or 1 for `reliabilityThreshold` will effectively disable the reliability checks, but still prevent versions from changing. For debugging purposes, setting `saveUnreliableVersionArtifacts` to `true` will isolate and save all uploads of unstable asset versions for later inspection and diffing.
 
 Option                                               | Default      | Description
 ------------------------------------------           | ------------ | -----------
 highReliability                                      | false        | Enable high reliability mode
 highReliabilityOptions.reliabilityThreshold          | 2            | Number of binary-stable imports of the same version required before a version will be cached and served
 highReliabilityOptions.saveUnreliableVersionArtifacts| true         | After a version is declared unreliable, save all subsequent transactions for the version for later inspection and debugging
-highReliabilityOptions.multiClient                   | false        | Require multiple clients to upload the same binary-stable version in order to increment the stability factor. i.e. if the same client uploads the same version twice in a row, it will not increase stability of the version.
+highReliabilityOptions.multiClient                   | false        | Require multiple clients to upload the same binary-stable version in order to increment the stability factor. i.e. if the same client uploads the same version twice in a row, it will not increase stability of the version
 
 ## Unity project Library Importer
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -15,7 +15,7 @@ Cache:
       highReliabilityOptions:
         reliabilityThreshold: 2
         saveUnreliableVersionArtifacts: true
-        requireUniqueClients: false
+        multiClient: false
     cache_fs:
       cachePath: ".cache_fs"
       cleanupOptions:
@@ -30,7 +30,7 @@ Cache:
       highReliabilityOptions:
         reliabilityThreshold: 2
         saveUnreliableVersionArtifacts: true
-        requireUniqueClients: false
+        multiClient: false
 Mirror:
   options:
     queueProcessDelay: 2000

--- a/config/default.yml
+++ b/config/default.yml
@@ -11,11 +11,24 @@ Cache:
         autosave: true
         autosaveInterval: 10000
         throttledSaves: false
+      highReliability: true
+      highReliabilityOptions:
+        reliabilityThreshold: 0
+        saveUnreliableVersionArtifacts: true
     cache_fs:
       cachePath: ".cache_fs"
       cleanupOptions:
         expireTimeSpan: "P30D"
         maxCacheSize: 0
+      persistence: true
+      persistenceOptions:
+        autosave: true
+        autosaveInterval: 10000
+        throttledSaves: false
+      highReliability: true
+      highReliabilityOptions:
+        reliabilityThreshold: 0
+        saveUnreliableVersionArtifacts: true
 Mirror:
   options:
     queueProcessDelay: 2000

--- a/config/default.yml
+++ b/config/default.yml
@@ -11,10 +11,11 @@ Cache:
         autosave: true
         autosaveInterval: 10000
         throttledSaves: false
-      highReliability: true
+      highReliability: false
       highReliabilityOptions:
-        reliabilityThreshold: 0
+        reliabilityThreshold: 2
         saveUnreliableVersionArtifacts: true
+        requireUniqueClients: false
     cache_fs:
       cachePath: ".cache_fs"
       cleanupOptions:
@@ -25,10 +26,11 @@ Cache:
         autosave: true
         autosaveInterval: 10000
         throttledSaves: false
-      highReliability: true
+      highReliability: false
       highReliabilityOptions:
-        reliabilityThreshold: 0
+        reliabilityThreshold: 2
         saveUnreliableVersionArtifacts: true
+        requireUniqueClients: false
 Mirror:
   options:
     queueProcessDelay: 2000

--- a/lib/cache/cache_base.js
+++ b/lib/cache/cache_base.js
@@ -257,8 +257,14 @@ class PutTransaction extends EventEmitter {
      */
     get filesHashStr() {
         return _.sortBy(this.files, 'type').reduce((result, file) => {
-            return result + file.type + file.byteHash.toString('hex');
-        }, "");
+
+            // FILE_TYPE.INFO content is ignored in determinism calculation, as it contains a preview image that will
+            // often fail to be cross-platform deterministic
+            return file.type === consts.FILE_TYPE.INFO
+                ? result + file.type
+                : result + file.type + file.byteHash.toString('hex');
+
+        }, this._guid.toString('hex') + this._hash.toString('hex'));
     }
 
     /**

--- a/lib/cache/cache_base.js
+++ b/lib/cache/cache_base.js
@@ -288,7 +288,7 @@ class PutTransaction extends EventEmitter {
      */
     async validateHash() {
         if(this.hash.compare(consts.ZERO_HASH) === 0) {
-            helpers.log(consts.LOG_ERR, `Invalidating transaction with zero (0) value hash for GUID ${this.guid}`);
+            helpers.log(consts.LOG_ERR, `Invalidating transaction with zero (0) value hash for GUID ${helpers.GUIDBufferToString(this.guid)}`);
             return this.invalidate();
         }
     }

--- a/lib/cache/cache_base.js
+++ b/lib/cache/cache_base.js
@@ -82,7 +82,7 @@ class CacheBase extends EventEmitter {
     /**
      *
      */
-    async _saveDb() {
+    _saveDb() {
         const save = promisify(this.db.saveDatabase).bind(this.db);
         return save();
     }

--- a/lib/cache/cache_base.js
+++ b/lib/cache/cache_base.js
@@ -208,6 +208,7 @@ class PutTransaction extends EventEmitter {
         this._guid = guid;
         this._hash = hash;
         this._isValid = true;
+        this._clientAddress = "";
     }
 
     /**
@@ -233,6 +234,22 @@ class PutTransaction extends EventEmitter {
      * @returns {Array}
      */
     get files() { return []; }
+
+    /**
+     *
+     * @param {String} val
+     */
+    set clientAddress(val) {
+        this._clientAddress = val;
+    }
+
+    /**
+     *
+     * @returns {String}
+     */
+    get clientAddress() {
+        return this._clientAddress;
+    }
 
     /**
      *

--- a/lib/cache/cache_base.js
+++ b/lib/cache/cache_base.js
@@ -7,11 +7,19 @@ const config = require('config');
 const path = require('path');
 const fs = require('fs-extra');
 const defaultsDeep = require('lodash').defaultsDeep;
+const { promisify } = require('util');
+const loki = require('lokijs');
+const ReliabilityManager = require('./reliability_manager');
+const _ = require('lodash');
+
+const kDbName = 'cache.db';
 
 class CacheBase extends EventEmitter {
     constructor() {
         super();
         this._optionOverrides = {};
+        this._db = null;
+        this._rm = null;
     }
 
     static get properties() {
@@ -43,28 +51,100 @@ class CacheBase extends EventEmitter {
 
     /**
      *
+     * @returns {LokiPersistenceAdapter}
+     */
+    get _persistenceAdapterClass() {
+        return loki.LokiFsAdapter;
+    }
+
+    /**
+     *
+     * @returns {string}
+     * @private
+     */
+    get _dbPath() {
+        return path.join(this._cachePath, kDbName);
+    }
+
+    /**
+     *
+     * @param options
+     * @returns {Promise<LokiConstructor>}
+     */
+    async _initDb(options) {
+        const db = new loki(this._dbPath, options);
+        const loadDb = promisify(db.loadDatabase).bind(db);
+        await loadDb({});
+
+        return db;
+    }
+
+    /**
+     *
+     */
+    async _saveDb() {
+        const save = promisify(this.db.saveDatabase).bind(this.db);
+        return save();
+    }
+
+    /**
+     *
+     * @returns {null|Loki}
+     */
+    get db() {
+        return this._db;
+    }
+
+    /**
+     *
+     * @returns {null|ReliabilityManager}
+     */
+    get reliabilityManager() {
+        return this._rm;
+    }
+
+    /**
+     *
      * @param {Object} options
      * @returns {Promise<any>}
      */
-    init(options) {
+    async init(options) {
         this._options = options;
 
         if(cluster.isMaster) {
             const p = this._cachePath;
             helpers.log(consts.LOG_INFO, `Cache path is ${p}`);
-            return fs.mkdirs(p);
+            await fs.mkdirs(p);
+
+            // Initialize database
+            let dbOpts = {};
+            const PersistenceAdapterClass = this._persistenceAdapterClass;
+
+            if(PersistenceAdapterClass !== null && this._options.persistence === true && this._options.persistenceOptions) {
+                dbOpts = this._options.persistenceOptions;
+                dbOpts.adapter = new PersistenceAdapterClass(this);
+            }
+
+            this._db = await this._initDb(dbOpts);
         }
-        else {
-            return Promise.resolve();
-        }
+
+        if(this._options.highReliability === true)
+            this._rm = new ReliabilityManager(this.db, this._cachePath, this._options.highReliabilityOptions);
     }
 
     /**
      *
      * @returns {Promise<any>}
      */
-    shutdown() {
-        return Promise.reject(new Error("Not implemented"));
+    async shutdown() {
+        if(!cluster.isMaster) return Promise.resolve();
+
+        if(!this._options.persistenceOptions.autosave) {
+            await this._saveDb();
+        }
+
+        const close = promisify(this.db.close).bind(this.db);
+        return close();
     }
 
     /**
@@ -104,17 +184,11 @@ class CacheBase extends EventEmitter {
      * @param {PutTransaction} transaction
      * @returns {Promise<any>}
      */
-    endPutTransaction(transaction) {
-        return Promise.reject(new Error("Not implemented"));
-    }
+    async endPutTransaction(transaction) {
+        await transaction.finalize();
 
-    // noinspection JSMethodCanBeStatic
-    /**
-     *
-     * @param {EventEmitter} worker
-     */
-    registerClusterWorker(worker) {
-        throw new Error("Not implemented");
+        if(this._rm !== null && this._options.highReliability)
+            return this._rm.processTransaction(transaction);
     }
 
     cleanup(dryRun = true) {
@@ -133,6 +207,7 @@ class PutTransaction extends EventEmitter {
         super();
         this._guid = guid;
         this._hash = hash;
+        this._isValid = true;
     }
 
     /**
@@ -161,6 +236,22 @@ class PutTransaction extends EventEmitter {
 
     /**
      *
+     * @returns {String}
+     */
+    get filesHashStr() {
+        return _.sortBy(this.files, 'type').reduce((result, file) => {
+            return result + file.type + file.byteHash.toString('hex');
+        }, "");
+    }
+
+    /**
+     *
+     * @returns {boolean}
+     */
+    get isValid() { return this._isValid; }
+
+    /**
+     *
      * @returns {Promise<any>}
      */
     finalize() {
@@ -174,6 +265,19 @@ class PutTransaction extends EventEmitter {
      * @returns {Promise<any>}
      */
     getWriteStream(type, size) {
+        return Promise.reject(new Error("Not implemented"));
+    }
+
+    async invalidate() {
+        this._isValid = false;
+    }
+
+    /**
+     *
+     * @param targetPath
+     * @returns {Promise<any>}
+     */
+    async writeFilesToPath(targetPath) {
         return Promise.reject(new Error("Not implemented"));
     }
 }

--- a/lib/cache/cache_base.js
+++ b/lib/cache/cache_base.js
@@ -271,8 +271,20 @@ class PutTransaction extends EventEmitter {
      *
      * @returns {Promise<any>}
      */
-    finalize() {
-        return Promise.resolve().then(() => this.emit('finalize'));
+    async finalize() {
+        await this.validateHash();
+        this.emit('finalize');
+    }
+
+    /**
+     *
+     * @returns {Promise<void>}
+     */
+    async validateHash() {
+        if(this.hash.compare(consts.ZERO_HASH) === 0) {
+            helpers.log(consts.LOG_ERR, `Invalidating transaction with zero (0) value hash for GUID ${this.guid}`);
+            return this.invalidate();
+        }
     }
 
     /**

--- a/lib/cache/cache_base.js
+++ b/lib/cache/cache_base.js
@@ -187,7 +187,7 @@ class CacheBase extends EventEmitter {
     async endPutTransaction(transaction) {
         await transaction.finalize();
 
-        if(this._rm !== null && this._options.highReliability)
+        if(this._rm !== null && this._options.highReliability && transaction.isValid)
             return this._rm.processTransaction(transaction);
     }
 

--- a/lib/cache/cache_fs.js
+++ b/lib/cache/cache_fs.js
@@ -96,15 +96,17 @@ class CacheFS extends CacheBase {
         const self = this;
         await super.endPutTransaction(transaction);
 
-        for(const file of transaction.files) {
-            try {
-                const filePath = await self._writeFileToCache(file.type, transaction.guid, transaction.hash, file.file);
-                helpers.log(consts.LOG_TEST, `Added file to cache: ${file.size} ${filePath}`);
-            }
-            catch(err) {
-                helpers.log(consts.LOG_DBG, err);
-            }
-        }
+        await Promise.all(
+            transaction.files.map(async (file) => {
+                try {
+                    const filePath = await self._writeFileToCache(file.type, transaction.guid, transaction.hash, file.file);
+                    helpers.log(consts.LOG_TEST, `Added file to cache: ${file.size} ${filePath}`);
+                }
+                catch(err) {
+                    helpers.log(consts.LOG_DBG, err);
+                }
+            })
+        );
     }
 
     cleanup(dryRun = true) {
@@ -158,22 +160,24 @@ class CacheFS extends CacheBase {
             clearTimeout(progressTimer);
             self.emit('cleanup_search_finish', progressData());
 
-            for(const d of deleteItems) {
-                const guidHash = CacheFS._extractGuidAndHashFromFilepath(d.path);
+            await Promise.all(
+                deleteItems.map(async (d) => {
+                    const guidHash = CacheFS._extractGuidAndHashFromFilepath(d.path);
 
-                // Make sure we're only deleting valid cached files
-                if(guidHash.guidStr.length === 0 || guidHash.hashStr.length === 0)
-                    continue;
+                    // Make sure we're only deleting valid cached files
+                    if(guidHash.guidStr.length === 0 || guidHash.hashStr.length === 0)
+                        return;
 
-                if(!dryRun) {
-                    await fs.unlink(d.path);
-                    if(this.reliabilityManager !== null) {
-                        this.reliabilityManager.removeEntry(guidHash.guidStr, guidHash.hashStr);
+                    if(!dryRun) {
+                        await fs.unlink(d.path);
+                        if(this.reliabilityManager !== null) {
+                            this.reliabilityManager.removeEntry(guidHash.guidStr, guidHash.hashStr);
+                        }
                     }
-                }
 
-                self.emit('cleanup_delete_item', d.path);
-            }
+                    self.emit('cleanup_delete_item', d.path);
+                })
+            );
 
             self.emit('cleanup_delete_finish', progressData());
         });
@@ -256,9 +260,7 @@ class PutTransactionFS extends PutTransaction {
 
     async invalidate() {
         await super.invalidate();
-        for(const f of this._files)
-            await fs.unlink(f.file);
-
+        await Promise.all(this._files.map(async (f) => await fs.unlink(f.file)));
         this._files = [];
     }
 
@@ -274,7 +276,7 @@ class PutTransactionFS extends PutTransaction {
             throw new Error("Invalid size for write stream");
         }
 
-        if(Object.values(consts.FILE_TYPE).indexOf(type) < 0) {
+        if(!Object.values(consts.FILE_TYPE).includes(type)) {
             throw new Error(`Unrecognized type '${type}' for transaction.`);
         }
 
@@ -291,15 +293,12 @@ class PutTransactionFS extends PutTransaction {
     }
 
     async writeFilesToPath(filePath) {
-        const paths = [];
         await fs.ensureDir(filePath);
-        for(const f of this._files) {
+        return Promise.all(this._files.map(async f => {
             const dest = `${path.join(filePath, f.byteHash.toString('hex'))}.${f.type}`;
             await fs.copyFile(f.file, dest);
-            paths.push(dest);
-        }
-
-        return paths;
+            return dest;
+        }));
     }
 }
 

--- a/lib/cache/cache_fs.js
+++ b/lib/cache/cache_fs.js
@@ -8,6 +8,7 @@ const consts = require('../constants');
 const moment = require('moment');
 const pick = require('lodash').pick;
 const crypto = require('crypto');
+const fileExtensions = require('lodash').invert(consts.FILE_TYPE);
 
 class CacheFS extends CacheBase {
     constructor() {
@@ -34,7 +35,7 @@ class CacheFS extends CacheBase {
      * @private
      */
     static _calcFilename(type, guid, hash) {
-        const ext = { 'i': 'info', 'a': 'bin', 'r': 'resource' }[type];
+        const ext = fileExtensions[type].toLowerCase();
         return `${helpers.GUIDBufferToString(guid)}-${hash.toString('hex')}.${ext}`;
     }
 
@@ -273,7 +274,7 @@ class PutTransactionFS extends PutTransaction {
             throw new Error("Invalid size for write stream");
         }
 
-        if(type !== 'a' && type !== 'i' && type !== 'r') {
+        if(Object.values(consts.FILE_TYPE).indexOf(type) < 0) {
             throw new Error(`Unrecognized type '${type}' for transaction.`);
         }
 

--- a/lib/cache/cache_fs.js
+++ b/lib/cache/cache_fs.js
@@ -7,10 +7,15 @@ const uuid = require('uuid');
 const consts = require('../constants');
 const moment = require('moment');
 const pick = require('lodash').pick;
+const crypto = require('crypto');
 
 class CacheFS extends CacheBase {
     constructor() {
         super();
+    }
+
+    get _optionsPath() {
+        return super._optionsPath + ".cache_fs";
     }
 
     static get properties() {
@@ -33,6 +38,18 @@ class CacheFS extends CacheBase {
         return `${helpers.GUIDBufferToString(guid)}-${hash.toString('hex')}.${ext}`;
     }
 
+    static _extractGuidAndHashFromFilepath(filePath) {
+        const fileName = path.basename(filePath).toLowerCase();
+        const matches = /^([0-9a-f]{32})-([0-9a-f]{32})\./.exec(fileName);
+        const result = { guidStr: "", hashStr: ""};
+        if(matches.length === 3) {
+            result.guidStr = matches[1];
+            result.hashStr = matches[2];
+        }
+
+        return result;
+    }
+
     /**
      *
      * @param {String} type
@@ -46,27 +63,16 @@ class CacheFS extends CacheBase {
         return path.join(this._cachePath, fileName.substr(0, 2), fileName);
     }
 
-    get _optionsPath() {
-        return super._optionsPath + ".cache_fs";
-    }
-
-    init(options) {
-        return super.init(options);
-    }
-
-    shutdown() {
-        return Promise.resolve();
-    }
-
-    async _addFileToCache(type, guid, hash, sourcePath) {
+    async _writeFileToCache(type, guid, hash, sourcePath) {
         const filePath = this._calcFilepath(type, guid, hash);
         await fs.move(sourcePath, filePath, { overwrite: true });
         return filePath;
     }
 
     async getFileInfo(type, guid, hash) {
-        const stats = await fs.stat(this._calcFilepath(type, guid, hash));
-        return {size: stats.size};
+        const filePath = this._calcFilepath(type, guid, hash);
+        const stats = await fs.stat(filePath);
+        return {filePath: filePath, size: stats.size};
     }
 
     getFileStream(type, guid, hash) {
@@ -87,18 +93,18 @@ class CacheFS extends CacheBase {
 
     async endPutTransaction(transaction) {
         const self = this;
+        await super.endPutTransaction(transaction);
 
-        const moveFile = async (file) => {
-            self._addFileToCache(file.type, transaction.guid, transaction.hash, file.file)
-                .then(filePath => helpers.log(consts.LOG_TEST, `Added file to cache: ${file.size} ${filePath}`),
-                        err => helpers.log(consts.LOG_ERR, err));
-        };
-
-        await transaction.finalize();
-        return Promise.all(transaction.files.map(moveFile));
+        for(const file of transaction.files) {
+            try {
+                const filePath = await self._writeFileToCache(file.type, transaction.guid, transaction.hash, file.file);
+                helpers.log(consts.LOG_TEST, `Added file to cache: ${file.size} ${filePath}`);
+            }
+            catch(err) {
+                helpers.log(consts.LOG_DBG, err);
+            }
+        }
     }
-
-    registerClusterWorker(worker) {}
 
     cleanup(dryRun = true) {
         const self = this;
@@ -131,7 +137,6 @@ class CacheFS extends CacheBase {
         const progressTimer = setInterval(progressEvent, 250);
 
         return helpers.readDir(self._cachePath, (item) => {
-            if(item.stats.isDirectory()) return next();
             item = {path: item.path, stats: pick(item.stats, ['atime', 'size'])};
             allItems.push(item);
             cacheSize += item.stats.size;
@@ -153,10 +158,20 @@ class CacheFS extends CacheBase {
             self.emit('cleanup_search_finish', progressData());
 
             for(const d of deleteItems) {
-                self.emit('cleanup_delete_item', d.path);
+                const guidHash = CacheFS._extractGuidAndHashFromFilepath(d.path);
+
+                // Make sure we're only deleting valid cached files
+                if(guidHash.guidStr.length === 0 || guidHash.hashStr.length === 0)
+                    continue;
+
                 if(!dryRun) {
                     await fs.unlink(d.path);
+                    if(this.reliabilityManager !== null) {
+                        this.reliabilityManager.removeEntry(guidHash.guidStr, guidHash.hashStr);
+                    }
                 }
+
+                self.emit('cleanup_delete_item', d.path);
             }
 
             self.emit('cleanup_delete_finish', progressData());
@@ -201,7 +216,8 @@ class PutTransactionFS extends PutTransaction {
                 self._files.push({
                     file: stream.file,
                     type: stream.type,
-                    size: stream.size
+                    size: stream.size,
+                    byteHash: stream.stream.byteHash
                 });
             }
             else {
@@ -237,6 +253,14 @@ class PutTransactionFS extends PutTransaction {
         return this._files;
     }
 
+    async invalidate() {
+        await super.invalidate();
+        for(const f of this._files)
+            await fs.unlink(f.file);
+
+        this._files = [];
+    }
+
     async finalize() {
         await this._closeAllStreams();
         return super.finalize();
@@ -254,7 +278,7 @@ class PutTransactionFS extends PutTransaction {
         }
 
         await fs.ensureFile(file);
-        const stream = fs.createWriteStream(file, this._writeOptions);
+        const stream = new HashedWriteStream(file, this._writeOptions);
         this._streams[type] = {
             file: file,
             type: type,
@@ -263,6 +287,39 @@ class PutTransactionFS extends PutTransaction {
         };
 
         return new Promise(resolve => stream.on('open', () => resolve(stream)));
+    }
+
+    async writeFilesToPath(filePath) {
+        const paths = [];
+        await fs.ensureDir(filePath);
+        for(const f of this._files) {
+            const dest = `${path.join(filePath, f.byteHash.toString('hex'))}.${f.type}`;
+            await fs.copyFile(f.file, dest);
+            paths.push(dest);
+        }
+
+        return paths;
+    }
+}
+
+class HashedWriteStream extends fs.WriteStream {
+    constructor(path, options) {
+        super(path, options);
+        this._hash = crypto.createHash('sha256');
+    }
+
+    _write(data, encoding, cb) {
+        this._hash.update(data, encoding);
+        super._write(data, encoding, cb);
+    }
+
+    _writev (chunks, cb) {
+        chunks.forEach(chunk => this._hash.update(chunk, 'ascii'));
+        super._writev(chunks, cb);
+    }
+
+    get byteHash() {
+        return this._hash.digest();
     }
 }
 

--- a/lib/cache/cache_ram.js
+++ b/lib/cache/cache_ram.js
@@ -372,7 +372,7 @@ class PutTransactionRAM extends PutTransaction {
             throw new Error("Invalid size for write stream");
         }
 
-        if(type !== 'a' && type !== 'i' && type !== 'r') {
+        if(Object.values(consts.FILE_TYPE).indexOf(type) < 0) {
             throw new Error(`Unrecognized type '${type}' for transaction.`);
         }
 

--- a/lib/cache/cache_ram.js
+++ b/lib/cache/cache_ram.js
@@ -372,7 +372,7 @@ class PutTransactionRAM extends PutTransaction {
             throw new Error("Invalid size for write stream");
         }
 
-        if(Object.values(consts.FILE_TYPE).indexOf(type) < 0) {
+        if(!Object.values(consts.FILE_TYPE).includes(type)) {
             throw new Error(`Unrecognized type '${type}' for transaction.`);
         }
 

--- a/lib/cache/cache_ram.js
+++ b/lib/cache/cache_ram.js
@@ -1,22 +1,20 @@
 'use strict';
 const { CacheBase, PutTransaction } = require('./cache_base');
 const { Readable, Writable }  = require('stream');
-const { promisify } = require('util');
 const helpers = require('../helpers');
 const consts = require('../constants');
 const path = require('path');
 const fs = require('fs-extra');
-const loki = require('lokijs');
+const { LokiFsAdapter } = require('lokijs');
 const uuid = require('uuid/v4');
+const crypto = require('crypto');
 
-const kDbName = 'cache.db';
 const kIndex = 'index';
 const kPageMeta = 'pages';
 
 class CacheRAM extends CacheBase {
     constructor() {
         super();
-        this._db = null;
         this._pages = {};
         this._serializeInProgress = false;
         this._guidRefs = {};
@@ -45,8 +43,8 @@ class CacheRAM extends CacheBase {
         return super._optionsPath + ".cache_ram";
     }
 
-    get _dbPath() {
-        return path.join(this._cachePath, kDbName);
+    get _persistenceAdapterClass() {
+        return PersistenceAdapter;
     }
 
     _allocPage(minSize) {
@@ -241,67 +239,38 @@ class CacheRAM extends CacheBase {
     /**
      *
      * @param options
-     * @returns {Promise<any>}
-     * @private
+     * @returns {Promise<LokiConstructor>}
      */
     async _initDb(options) {
-        const db = new loki(this._dbPath, options);
-        const loadDb = promisify(db.loadDatabase).bind(db);
-        this._db = db;
-
-        await loadDb({});
+        const db = await super._initDb(options);
 
         this._index = db.getCollection(kIndex);
         this._pageMeta = db.getCollection(kPageMeta);
 
         if(this._options.persistence === true && this._index !== null && this._pageMeta !== null) {
-            return this._deserialize();
+            await this._deserialize();
+        }
+        else {
+            this._pageMeta = db.addCollection(kPageMeta, {
+                unique: ["index"],
+                indices: ["dirty"]
+            });
+
+            this._index = db.addCollection(kIndex, {
+                unique: ["fileId"],
+                indices: ["size"]
+            });
+
+            this._clearCache();
         }
 
-        this._pageMeta = db.addCollection(kPageMeta, {
-            unique: ["index"],
-            indices: ["dirty"]
-        });
-
-        this._index = db.addCollection(kIndex, {
-            unique: ["fileId"],
-            indices: ["size"]
-        });
-
-        this._clearCache();
-    }
-
-    /**
-     *
-     * @private
-     */
-    async _saveDb() {
-        const save = promisify(this._db.saveDatabase).bind(this._db);
-        return save();
-    }
-
-    async init(options) {
-        await super.init(options);
-
-        let dbOpts = {};
-        if(this._options.persistence === true && this._options.persistenceOptions) {
-            dbOpts = this._options.persistenceOptions;
-            dbOpts.adapter = new PersistenceAdapter(this);
-        }
-
-        return this._initDb(dbOpts);
-    }
-
-    async shutdown() {
-        await this._saveDb();
-        const close = promisify(this._db.close).bind(this._db);
-        return close();
+        return db;
     }
 
     async getFileInfo(type, guid, hash) {
         const key = CacheRAM._calcIndexKey(type, guid, hash);
         const entry = this._index.by('fileId', key);
-        if(entry == null) throw new Error(`File not found for ${key}`);
+        if(!entry) throw new Error(`File not found for ${key}`);
         return { size: entry.size, lastAccessTime: entry.lastAccessTime };
     }
 
@@ -350,15 +319,13 @@ class CacheRAM extends CacheBase {
 
     async endPutTransaction(transaction) {
         await this._waitForSerialize();
-        await transaction.finalize();
+        await super.endPutTransaction(transaction);
 
         for(const file of transaction.files) {
             this._addFileToCache(file.type, transaction.guid, transaction.hash, file.buffer)
                 .catch(err => helpers.log(consts.LOG_ERR, err));
         }
     }
-
-    registerClusterWorker(worker) {}
 
     cleanup(dryRun = true) {
         // Not supported
@@ -378,16 +345,25 @@ class PutTransactionRAM extends PutTransaction {
     }
 
     get files() {
-        return this._finished;
+        return this.isValid ? this._finished : [];
     }
 
     async finalize() {
-        this._finished = Object.values(this._streams);
-        const ok = this._finished.every(file => {
-            return file.pos === file.buffer.length;
+        const streams = Object.values(this._streams);
+        const ok = streams.every(s => {
+            return s.stream.writePosition === s.stream.buffer.length;
         });
 
         if(!ok) throw new Error("Transaction failed; file size mismatch");
+
+        this._finished = streams.map(s => {
+            return {
+                type: s.type,
+                buffer: s.stream.buffer,
+                byteHash: s.stream.byteHash
+            }
+        });
+
         return super.finalize();
     }
 
@@ -400,34 +376,77 @@ class PutTransactionRAM extends PutTransaction {
             throw new Error(`Unrecognized type '${type}' for transaction.`);
         }
 
+        const stream = new HashedBufferWritable({size: size});
+
         this._streams[type] = {
             type: type,
-            buffer: Buffer.alloc(size, 0, 'ascii'),
-            pos: 0
+            stream: stream
         };
 
-        const self = this;
-        return new Writable({
-            write(chunk, encoding, cb) {
-                const file = self._streams[type];
+        return stream;
+    }
 
-                if (file.buffer.length - file.pos >= chunk.length) {
-                    chunk.copy(file.buffer, file.pos, 0, chunk.length);
-                    file.pos += chunk.length;
-                }
-                else {
-                    helpers.log(consts.LOG_ERR, "Attempt to write over stream buffer allocation!");
-                }
+    async writeFilesToPath(filePath) {
+        await fs.ensureDir(filePath);
+        const promises = this.files.map(f => {
+            return new Promise((resolve, reject) => {
+                const destPath = `${path.join(filePath, f.byteHash.toString('hex'))}.${f.type}`;
+                const destStream = fs.createWriteStream(destPath);
 
-                cb();
-            }
+                const bufferReader = new Readable({
+                    read() {
+                        this.push(f.buffer);
+                        this.push(null);
+                    }
+                });
+
+                bufferReader.pipe(destStream);
+                bufferReader.on('end', () => resolve(destPath));
+                bufferReader.on('error', e => reject(e));
+            });
         });
+
+        return Promise.all(promises);
+    }
+}
+
+class HashedBufferWritable extends Writable {
+    constructor(options) {
+        super(options);
+        this._hash = crypto.createHash('sha256');
+        this._buffer = Buffer.alloc(options.size, 0, 'ascii');
+        this._pos = 0;
+    }
+
+    _write(chunk, encoding, cb) {
+        if (this._buffer.length - this._pos >= chunk.length) {
+            this._hash.update(chunk, encoding);
+            chunk.copy(this._buffer, this._pos, 0, chunk.length);
+            this._pos += chunk.length;
+        }
+        else {
+            helpers.log(consts.LOG_ERR, "Attempt to write over stream buffer allocation!");
+        }
+
+        cb();
+    }
+
+    get byteHash() {
+        return this._hash.digest();
+    }
+
+    get buffer() {
+        return this._buffer;
+    }
+
+    get writePosition() {
+        return this._pos;
     }
 }
 
 module.exports = CacheRAM;
 
-class PersistenceAdapter extends loki.LokiFsAdapter {
+class PersistenceAdapter extends LokiFsAdapter {
     constructor(cache) {
         super();
         this._cache = cache;

--- a/lib/cache/reliability_manager.js
+++ b/lib/cache/reliability_manager.js
@@ -3,16 +3,22 @@ const path = require('path');
 const helpers = require('../helpers');
 const cm = require('../cluster_messages');
 const consts = require('../constants');
+const crypto = require('crypto');
+const _ = require('lodash');
 
 const kDbVersionReliability = 'version_reliability_manager_versions';
 const kUnreliableRootDir = '.unreliable';
-const kDefaultReliabilityFactor = 0;
+const defaultOptions = {
+    reliabilityThreshold: 0,
+    requireUniqueClients: false
+};
 
 class ReliabilityManager {
     constructor(db, cachePath, options) {
         this._db = db;
         this._cachePath = cachePath;
-        this._options = options;
+        this._options = options || {};
+        _.defaults(this._options, defaultOptions);
 
         if(this._db) {
             this._db_versionReliability = db.getCollection(kDbVersionReliability);
@@ -40,24 +46,43 @@ class ReliabilityManager {
             return cm.send('_updateReliabilityFactorForVersion', params);
         }
 
-        const entry = this.getEntry(params.guidStr, params.hashStr);
-        if(!entry) {
-            return this.createEntry(params.guidStr, params.hashStr, params.versionHashStr, kDefaultReliabilityFactor);
+        const entry = this.getEntry(params.guidStr, params.hashStr, true);
+        if(!entry.versionHash) {
+            entry.versionHash = params.versionHashStr;
+            entry.clientId = params.clientId;
         }
 
-        // Previously unstable versions cannot recover
-        if(entry.factor < 0) return entry;
+        if(entry.state !== ReliabilityManager.reliabilityStates.Pending) {
+            if(entry.state === ReliabilityManager.reliabilityStates.ReliableNew) {
+                entry.state = ReliabilityManager.reliabilityStates.Reliable;
+                this._db_versionReliability.update(entry);
+            }
+
+            return entry;
+        }
+
+        if(this._options.requireUniqueClients && params.clientId === entry.clientId) {
+            helpers.log(consts.LOG_DBG, `Ignoring duplicate transaction for GUID: ${params.guidStr} Hash: ${params.hashStr} from previous client (requireUniqueClients = true)`);
+            return entry;
+        }
+
+        entry.clientId = params.clientId;
 
         if(entry.versionHash === params.versionHashStr) {
             entry.factor += 1;
             helpers.log(consts.LOG_DBG, `GUID: ${params.guidStr} Hash: ${params.hashStr} ReliabilityFactor: ${entry.factor}`);
         }
         else {
-            entry.factor = -1;
+            entry.state = ReliabilityManager.reliabilityStates.Unreliable;
             helpers.log(consts.LOG_ERR, `Unreliable version detected! GUID: ${params.guidStr} Hash: ${params.hashStr}`);
         }
 
+        if(entry.factor >= this._options.reliabilityThreshold)
+            entry.state = ReliabilityManager.reliabilityStates.ReliableNew;
+
         this._db_versionReliability.update(entry);
+
+        entry.wasUpdated = true;
         return entry;
     }
 
@@ -71,6 +96,7 @@ class ReliabilityManager {
             guidStr: helpers.GUIDBufferToString(trx.guid),
             hashStr: trx.hash.toString('hex'),
             versionHashStr: trx.filesHashStr,
+            clientId: crypto.createHash('md5').update(trx.clientAddress).digest().toString('hex'),
             files: trx.files.map(f => {
                 return {
                     type: f.type,
@@ -82,46 +108,40 @@ class ReliabilityManager {
 
         const info = await this._updateReliabilityFactorForVersion(params);
 
-        if(info.factor < 0 && this._options.saveUnreliableVersionArtifacts) {
+        if(info.state === ReliabilityManager.reliabilityStates.Unreliable && this._options.saveUnreliableVersionArtifacts) {
             const unreliableFilePath = path.join(this._cachePath, kUnreliableRootDir, params.guidStr, params.hashStr);
             await trx.writeFilesToPath(unreliableFilePath);
             helpers.log(consts.LOG_DBG, `Unreliable version artifacts saved to ${unreliableFilePath}`);
         }
 
-        if(info.factor !== this._options.reliabilityThreshold) {
-            helpers.log(consts.LOG_DBG, `Invalidating transaction from client at ${trx.clientAddress} for GUID: ${params.guidStr} Hash: ${params.hashStr} because ReliabilityFactor (${info.factor}) != ReliabilityThreshold (${this._options.reliabilityThreshold})`);
+        if(info.state !== ReliabilityManager.reliabilityStates.ReliableNew) {
+            helpers.log(consts.LOG_DBG, `Invalidating transaction from client at ${trx.clientAddress} for GUID: ${params.guidStr} Hash: ${params.hashStr} ReliabilityState: ${info.state.toString()}`);
             await trx.invalidate();
         }
     }
 
     /**
      *
-     * @param guidStr
-     * @param hashStr
+     * @param {string} guidStr
+     * @param {string} hashStr
+     * @param {boolean} create
      * @returns {Object}
      */
-    getEntry(guidStr, hashStr) {
+    getEntry(guidStr, hashStr, create = false) {
         const versionId = `${guidStr}-${hashStr}`;
-        return this._db_versionReliability.by("versionId", versionId);
-    }
+        let entry = this._db_versionReliability.by("versionId", versionId);
 
-    /**
-     *
-     * @param guidStr
-     * @param hashStr
-     * @param versionHashStr
-     * @param factor
-     * @returns {Object}
-     */
-    createEntry(guidStr, hashStr, versionHashStr, factor) {
-        const versionId = `${guidStr}-${hashStr}`;
-        return this._db_versionReliability.insert({
-            versionId: versionId,
-            guid: guidStr,
-            hash: hashStr,
-            versionHash: versionHashStr,
-            factor: factor
-        });
+        if(!entry && create === true) {
+            entry = this._db_versionReliability.insert({
+                versionId: versionId,
+                guid: guidStr,
+                hash: hashStr,
+                factor: 0,
+                state: ReliabilityManager.reliabilityStates.Pending
+            });
+        }
+
+        return entry;
     }
 
     /**
@@ -130,10 +150,15 @@ class ReliabilityManager {
      * @param hashStr
      */
     removeEntry(guidStr, hashStr) {
-        const entry = this.getEntry(guidStr, hashStr);
-        if(entry)
-            this._db_versionReliability.remove(entry);
+        this._db_versionReliability.findAndRemove({versionId: `${guidStr}-${hashStr}`});
     }
 }
+
+ReliabilityManager.reliabilityStates = {
+    Unreliable: 'Unreliable',
+    Pending: 'Pending',
+    ReliableNew: 'ReliableNew',
+    Reliable: 'Reliable'
+};
 
 module.exports = ReliabilityManager;

--- a/lib/cache/reliability_manager.js
+++ b/lib/cache/reliability_manager.js
@@ -10,7 +10,7 @@ const kDbVersionReliability = 'version_reliability_manager_versions';
 const kUnreliableRootDir = '.unreliable';
 const defaultOptions = {
     reliabilityThreshold: 0,
-    requireUniqueClients: false
+    multiClient: false
 };
 
 class ReliabilityManager {
@@ -61,8 +61,8 @@ class ReliabilityManager {
             return entry;
         }
 
-        if(this._options.requireUniqueClients && params.clientId === entry.clientId) {
-            helpers.log(consts.LOG_DBG, `Ignoring duplicate transaction for GUID: ${params.guidStr} Hash: ${params.hashStr} from previous client (requireUniqueClients = true)`);
+        if(this._options.multiClient && params.clientId === entry.clientId) {
+            helpers.log(consts.LOG_DBG, `Ignoring duplicate transaction for GUID: ${params.guidStr} Hash: ${params.hashStr} from previous client (multiClient = true)`);
             return entry;
         }
 

--- a/lib/cache/reliability_manager.js
+++ b/lib/cache/reliability_manager.js
@@ -30,7 +30,7 @@ class ReliabilityManager {
             }
         }
 
-        cm.listenFor("_updateReliabilityFactorForVersion", async (data) => {
+        cm.listenFor("_updateReliabilityFactorForVersion", (data) => {
             return this._updateReliabilityFactorForVersion(data);
         });
     }
@@ -125,7 +125,7 @@ class ReliabilityManager {
      * @param {string} guidStr
      * @param {string} hashStr
      * @param {boolean} create
-     * @returns {Object}
+     * @returns {null|Object}
      */
     getEntry(guidStr, hashStr, create = false) {
         const versionId = `${guidStr}-${hashStr}`;

--- a/lib/cache/reliability_manager.js
+++ b/lib/cache/reliability_manager.js
@@ -1,0 +1,139 @@
+const cluster = require('cluster');
+const path = require('path');
+const helpers = require('../helpers');
+const cm = require('../cluster_messages');
+const consts = require('../constants');
+
+const kDbVersionReliability = 'version_reliability_manager_versions';
+const kUnreliableRootDir = '.unreliable';
+const kDefaultReliabilityFactor = 0;
+
+class ReliabilityManager {
+    constructor(db, cachePath, options) {
+        this._db = db;
+        this._cachePath = cachePath;
+        this._options = options;
+
+        if(this._db) {
+            this._db_versionReliability = db.getCollection(kDbVersionReliability);
+            if (this._db_versionReliability == null) {
+                this._db_versionReliability = db.addCollection(kDbVersionReliability, {
+                    unique: ["versionId"],
+                    indices: ["guid", "hash"]
+                });
+            }
+        }
+
+        cm.listenFor("_updateReliabilityFactorForVersion", async (data) => {
+            return this._updateReliabilityFactorForVersion(data);
+        });
+    }
+
+    /**
+     *
+     * @param {Object} params
+     * @returns {Promise<Object>}
+     * @private
+     */
+    async _updateReliabilityFactorForVersion(params) {
+        if(cluster.isWorker) {
+            return cm.send('_updateReliabilityFactorForVersion', params);
+        }
+
+        const entry = this.getEntry(params.guidStr, params.hashStr);
+        if(!entry) {
+            return this.createEntry(params.guidStr, params.hashStr, params.versionHashStr, kDefaultReliabilityFactor);
+        }
+
+        // Previously unstable versions cannot recover
+        if(entry.factor < 0) return entry;
+
+        if(entry.versionHash === params.versionHashStr) {
+            entry.factor += 1;
+            helpers.log(consts.LOG_DBG, `GUID: ${params.guidStr} Hash: ${params.hashStr} ReliabilityFactor: ${entry.factor}`);
+        }
+        else {
+            entry.factor = -1;
+            helpers.log(consts.LOG_ERR, `Unreliable version detected! GUID: ${params.guidStr} Hash: ${params.hashStr}`);
+        }
+
+        this._db_versionReliability.update(entry);
+        return entry;
+    }
+
+    /**
+     *
+     * @param {PutTransaction} trx
+     * @returns {Promise<void>}
+     */
+    async processTransaction(trx) {
+        const params = {
+            guidStr: helpers.GUIDBufferToString(trx.guid),
+            hashStr: trx.hash.toString('hex'),
+            versionHashStr: trx.filesHashStr,
+            files: trx.files.map(f => {
+                return {
+                    type: f.type,
+                    path: f.file,
+                    byteHashStr: f.byteHash.toString('hex')
+                }
+            })
+        };
+
+        const info = await this._updateReliabilityFactorForVersion(params);
+
+        if(info.factor < 0 && this._options.saveUnreliableVersionArtifacts) {
+            const unreliableFilePath = path.join(this._cachePath, kUnreliableRootDir, params.guidStr, params.hashStr);
+            await trx.writeFilesToPath(unreliableFilePath);
+            helpers.log(consts.LOG_DBG, `Unreliable version artifacts saved to ${unreliableFilePath}`);
+        }
+
+        if(info.factor !== this._options.reliabilityThreshold) {
+            helpers.log(consts.LOG_DBG, `Invalidating transaction from client at ${trx.clientAddress} for GUID: ${params.guidStr} Hash: ${params.hashStr} because ReliabilityFactor (${info.factor}) != ReliabilityThreshold (${this._options.reliabilityThreshold})`);
+            await trx.invalidate();
+        }
+    }
+
+    /**
+     *
+     * @param guidStr
+     * @param hashStr
+     * @returns {Object}
+     */
+    getEntry(guidStr, hashStr) {
+        const versionId = `${guidStr}-${hashStr}`;
+        return this._db_versionReliability.by("versionId", versionId);
+    }
+
+    /**
+     *
+     * @param guidStr
+     * @param hashStr
+     * @param versionHashStr
+     * @param factor
+     * @returns {Object}
+     */
+    createEntry(guidStr, hashStr, versionHashStr, factor) {
+        const versionId = `${guidStr}-${hashStr}`;
+        return this._db_versionReliability.insert({
+            versionId: versionId,
+            guid: guidStr,
+            hash: hashStr,
+            versionHash: versionHashStr,
+            factor: factor
+        });
+    }
+
+    /**
+     *
+     * @param guidStr
+     * @param hashStr
+     */
+    removeEntry(guidStr, hashStr) {
+        const entry = this.getEntry(guidStr, hashStr);
+        if(entry)
+            this._db_versionReliability.remove(entry);
+    }
+}
+
+module.exports = ReliabilityManager;

--- a/lib/cache/reliability_manager.js
+++ b/lib/cache/reliability_manager.js
@@ -49,7 +49,6 @@ class ReliabilityManager {
         const entry = this.getEntry(params.guidStr, params.hashStr, true);
         if(!entry.versionHash) {
             entry.versionHash = params.versionHashStr;
-            entry.clientId = params.clientId;
         }
 
         if(entry.state !== ReliabilityManager.reliabilityStates.Pending) {

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -50,11 +50,7 @@ class CacheClient {
     }
 
     static get fileTypes() {
-        return {
-            info: 'i',
-            resource: 'r',
-            asset: 'a'
-        }
+        return consts.FILE_TYPE;
     }
 
     /**

--- a/lib/cluster_messages.js
+++ b/lib/cluster_messages.js
@@ -1,0 +1,85 @@
+const cluster = require('cluster');
+const uuid = require('uuid');
+const { EventEmitter } = require('events');
+
+const kMsgPrefix = "__ClusterMessage__";
+
+class ClusterMessages extends EventEmitter {
+    constructor() {
+        super();
+        this._callbacks = {};
+        this._listeners = {};
+        this._initMessageHandlers();
+    }
+
+    _initMessageHandlers() {
+        if(cluster.isMaster) {
+            cluster.on('message', (worker, message) => {
+                if(!message || !message.hasOwnProperty(kMsgPrefix)) return;
+
+                const msg = message[kMsgPrefix];
+                if (!this._listeners.hasOwnProperty(msg)) return;
+
+                this._listeners[msg](message.data)
+                    .then(result => {
+                        const payload = {
+                            msgId: message.msgId,
+                            result: result
+                        };
+
+                        payload[kMsgPrefix] = msg;
+
+                        cluster.workers[message.workerId].send(payload);
+                    });
+            });
+        }
+        else {
+            process.on('message', (message) => {
+                if(!message || !message.hasOwnProperty('msgId')) return;
+
+                const cb = this._callbacks[message.msgId];
+                if(!cb) return;
+
+                cb.resolve(message.result);
+            });
+        }
+    }
+
+    /**
+     *
+     * @param {String} msg
+     * @param {Function<Promise<any>>} listener
+     */
+    listenFor(msg, listener) {
+        this._listeners[msg] = listener;
+    }
+
+    /**
+     *
+     * @param {String} msg
+     * @param {Object} data
+     * @returns {Promise<*>}
+     */
+    async send(msg, data) {
+        if(!cluster.isWorker) return Promise.reject("Function can only be called from a worker node.");
+
+        return new Promise((resolve, reject) => {
+            const payload = {
+                msgId: uuid.v4(),
+                data: data,
+                workerId: cluster.worker.id
+            };
+
+            payload[kMsgPrefix] = msg;
+
+            this._callbacks[payload.msgId] = {
+                resolve: resolve,
+                reject: reject
+            };
+
+            process.send(payload);
+        });
+    }
+}
+
+module.exports = new ClusterMessages();

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -20,6 +20,6 @@ constants.ID_SIZE = constants.GUID_SIZE + constants.HASH_SIZE;
 constants.VERSION_SIZE = constants.UINT32_SIZE;
 constants.SIZE_SIZE = constants.UINT64_SIZE;
 constants.DEFAULT_LOG_LEVEL = constants.LOG_INFO;
-
+constants.ZERO_HASH = Buffer.alloc(constants.HASH_SIZE, 0);
 Object.freeze(constants);
 module.exports = constants;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -13,7 +13,12 @@ const constants = {
     LOG_TEST: 4,
     LOG_DBG: 5,
     DEFAULT_PORT: 8126,
-    DEFAULT_WORKERS: 0
+    DEFAULT_WORKERS: 0,
+    FILE_TYPE: {
+        INFO: 'i',
+        BIN: 'a',
+        RESOURCE: 'r'
+    }
 };
 
 constants.ID_SIZE = constants.GUID_SIZE + constants.HASH_SIZE;

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,3 +10,4 @@ exports.CacheBase = require('./cache/cache_base').CacheBase;
 exports.PutTransaction = require('./cache/cache_base').PutTransaction;
 exports.CacheFS = require('./cache/cache_fs');
 exports.CacheRAM = require('./cache/cache_ram');
+exports.ReliabilityManager = require('./cache/reliability_manager');

--- a/lib/server/client_stream_processor.js
+++ b/lib/server/client_stream_processor.js
@@ -11,7 +11,7 @@ class ClientStreamProcessor extends Transform {
     constructor(options) {
         super();
 
-        this._options = options;
+        this._options = options || {};
         this._headerBuf = Buffer.allocUnsafe(MAX_HEADER_SIZE);
         this._errState = null;
         this._readState = {};

--- a/lib/server/client_stream_processor.js
+++ b/lib/server/client_stream_processor.js
@@ -8,9 +8,10 @@ const MAX_HEADER_SIZE = consts.CMD_SIZE + consts.ID_SIZE;
 const kSource = Symbol();
 
 class ClientStreamProcessor extends Transform {
-    constructor() {
+    constructor(options) {
         super();
 
+        this._options = options;
         this._headerBuf = Buffer.allocUnsafe(MAX_HEADER_SIZE);
         this._errState = null;
         this._readState = {};
@@ -25,6 +26,14 @@ class ClientStreamProcessor extends Transform {
 
         this._registerEventListeners();
         this._init();
+    }
+
+    /**
+     *
+     * @returns {string}
+     */
+    get clientAddress() {
+        return this._options.clientAddress || "";
     }
 
     _registerEventListeners() {

--- a/lib/server/command_processor.js
+++ b/lib/server/command_processor.js
@@ -298,6 +298,7 @@ class CommandProcessor extends Duplex {
         }
 
         this._trx = await this[kCache].createPutTransaction(guid, hash);
+        this._trx.clientAddress = this[kSource].clientAddress;
         helpers.log(consts.LOG_DBG, `Start transaction for GUID: ${helpers.GUIDBufferToString(guid)} Hash: ${hash.toString('hex')}`);
     }
 

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -5,7 +5,6 @@ const helpers = require('../helpers');
 const ClientStreamProcessor  = require('./client_stream_processor');
 const CommandProcessor = require('./command_processor');
 const TransactionMirror = require('./transaction_mirror');
-const ip = require('ip');
 
 class CacheServer {
     /**
@@ -94,6 +93,7 @@ class CacheServer {
 
     stop() {
         return new Promise((resolve, reject) => {
+            if(!this._server) return resolve();
             this._server.close(err => {
                 if(err) reject(err);
                 else resolve();

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -74,7 +74,7 @@ class CacheServer {
                     helpers.log(consts.LOG_ERR, err);
                 });
 
-            socket.pipe(new ClientStreamProcessor()) // Transform the incoming byte stream into commands and file data
+            socket.pipe(new ClientStreamProcessor({clientAddress: socket.remoteAddress})) // Transform the incoming byte stream into commands and file data
                 .pipe(cmdProc)                       // Execute commands and interface with the cache module
                 .pipe(socket);                       // Connect back to socket to send files
         });

--- a/main.js
+++ b/main.js
@@ -129,8 +129,7 @@ Cache.init(cacheOpts)
             }
 
             for(let i = 0; i < program.workers; i++) {
-                const worker = cluster.fork();
-                Cache.registerClusterWorker(worker);
+                cluster.fork();
             }
         }
         else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "unity-cache-server",
-  "version": "6.0.2",
+  "version": "6.1.0-preview.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
       "requires": {
-        "color-convert": "1.9.1"
+        "color-convert": "^1.9.0"
       }
     },
     "argparse": {
@@ -17,7 +17,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "bluebird": {
@@ -31,9 +31,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
       "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "supports-color": "4.5.0"
+        "ansi-styles": "^3.1.0",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^4.0.0"
       },
       "dependencies": {
         "has-flag": {
@@ -46,7 +46,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -56,7 +56,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-spinners": {
@@ -69,7 +69,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -109,11 +109,11 @@
       "integrity": "sha1-Iu9zAzBTgIDSm4wVHckUav3oipk=",
       "dev": true,
       "requires": {
-        "js-yaml": "3.10.0",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.5",
-        "minimist": "1.2.0",
-        "request": "2.83.0"
+        "js-yaml": "^3.6.1",
+        "lcov-parse": "^0.0.10",
+        "log-driver": "^1.2.5",
+        "minimist": "^1.2.0",
+        "request": "^2.79.0"
       },
       "dependencies": {
         "js-yaml": {
@@ -122,8 +122,8 @@
           "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           },
           "dependencies": {
             "argparse": {
@@ -132,7 +132,7 @@
               "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
               "dev": true,
               "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
               },
               "dependencies": {
                 "sprintf-js": {
@@ -175,28 +175,28 @@
           "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           },
           "dependencies": {
             "aws-sign2": {
@@ -223,7 +223,7 @@
               "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
               "dev": true,
               "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
               },
               "dependencies": {
                 "delayed-stream": {
@@ -252,9 +252,9 @@
               "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
               "dev": true,
               "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
               },
               "dependencies": {
                 "asynckit": {
@@ -271,8 +271,8 @@
               "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
               "dev": true,
               "requires": {
-                "ajv": "5.2.3",
-                "har-schema": "2.0.0"
+                "ajv": "^5.1.0",
+                "har-schema": "^2.0.0"
               },
               "dependencies": {
                 "ajv": {
@@ -281,10 +281,10 @@
                   "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
                   "dev": true,
                   "requires": {
-                    "co": "4.6.0",
-                    "fast-deep-equal": "1.0.0",
-                    "json-schema-traverse": "0.3.1",
-                    "json-stable-stringify": "1.0.1"
+                    "co": "^4.6.0",
+                    "fast-deep-equal": "^1.0.0",
+                    "json-schema-traverse": "^0.3.0",
+                    "json-stable-stringify": "^1.0.1"
                   },
                   "dependencies": {
                     "co": {
@@ -311,7 +311,7 @@
                       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                       "dev": true,
                       "requires": {
-                        "jsonify": "0.0.0"
+                        "jsonify": "~0.0.0"
                       },
                       "dependencies": {
                         "jsonify": {
@@ -338,10 +338,10 @@
               "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
               "dev": true,
               "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.0.2"
+                "boom": "4.x.x",
+                "cryptiles": "3.x.x",
+                "hoek": "4.x.x",
+                "sntp": "2.x.x"
               },
               "dependencies": {
                 "boom": {
@@ -350,7 +350,7 @@
                   "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
                   "dev": true,
                   "requires": {
-                    "hoek": "4.2.0"
+                    "hoek": "4.x.x"
                   }
                 },
                 "cryptiles": {
@@ -359,7 +359,7 @@
                   "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
                   "dev": true,
                   "requires": {
-                    "boom": "5.2.0"
+                    "boom": "5.x.x"
                   },
                   "dependencies": {
                     "boom": {
@@ -368,7 +368,7 @@
                       "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
                       "dev": true,
                       "requires": {
-                        "hoek": "4.2.0"
+                        "hoek": "4.x.x"
                       }
                     }
                   }
@@ -385,7 +385,7 @@
                   "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
                   "dev": true,
                   "requires": {
-                    "hoek": "4.2.0"
+                    "hoek": "4.x.x"
                   }
                 }
               }
@@ -396,9 +396,9 @@
               "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
               "dev": true,
               "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -437,9 +437,9 @@
                       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
                       "dev": true,
                       "requires": {
-                        "assert-plus": "1.0.0",
+                        "assert-plus": "^1.0.0",
                         "core-util-is": "1.0.2",
-                        "extsprintf": "1.3.0"
+                        "extsprintf": "^1.2.0"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -458,14 +458,14 @@
                   "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
                   "dev": true,
                   "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "1.0.0",
-                    "bcrypt-pbkdf": "1.0.1",
-                    "dashdash": "1.14.1",
-                    "ecc-jsbn": "0.1.1",
-                    "getpass": "0.1.7",
-                    "jsbn": "0.1.1",
-                    "tweetnacl": "0.14.5"
+                    "asn1": "~0.2.3",
+                    "assert-plus": "^1.0.0",
+                    "bcrypt-pbkdf": "^1.0.0",
+                    "dashdash": "^1.12.0",
+                    "ecc-jsbn": "~0.1.1",
+                    "getpass": "^0.1.1",
+                    "jsbn": "~0.1.0",
+                    "tweetnacl": "~0.14.0"
                   },
                   "dependencies": {
                     "asn1": {
@@ -481,7 +481,7 @@
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "tweetnacl": "0.14.5"
+                        "tweetnacl": "^0.14.3"
                       }
                     },
                     "dashdash": {
@@ -490,7 +490,7 @@
                       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                       "dev": true,
                       "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                       }
                     },
                     "ecc-jsbn": {
@@ -500,7 +500,7 @@
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                       }
                     },
                     "getpass": {
@@ -509,7 +509,7 @@
                       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                       "dev": true,
                       "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                       }
                     },
                     "jsbn": {
@@ -554,7 +554,7 @@
               "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
               "dev": true,
               "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "~1.30.0"
               },
               "dependencies": {
                 "mime-db": {
@@ -601,7 +601,7 @@
               "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
               "dev": true,
               "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
               },
               "dependencies": {
                 "punycode": {
@@ -618,7 +618,7 @@
               "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.0.1"
               }
             },
             "uuid": {
@@ -656,7 +656,7 @@
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "samsam": "1.x"
       }
     },
     "fs-extra": {
@@ -664,9 +664,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "graceful-fs": {
@@ -690,8 +690,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsonfile": {
@@ -699,7 +699,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "just-extend": {
@@ -724,7 +724,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "requires": {
-        "chalk": "2.3.0"
+        "chalk": "^2.0.1"
       }
     },
     "lokijs": {
@@ -775,7 +775,7 @@
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -791,7 +791,7 @@
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "concat-map": {
@@ -833,12 +833,12 @@
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-readlink": {
@@ -871,8 +871,8 @@
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -893,8 +893,8 @@
           "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
           "dev": true,
           "requires": {
-            "lodash._basecopy": "3.0.1",
-            "lodash.keys": "3.1.2"
+            "lodash._basecopy": "^3.0.0",
+            "lodash.keys": "^3.0.0"
           }
         },
         "lodash._basecopy": {
@@ -927,9 +927,9 @@
           "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
           "dev": true,
           "requires": {
-            "lodash._baseassign": "3.2.0",
-            "lodash._basecreate": "3.0.3",
-            "lodash._isiterateecall": "3.0.9"
+            "lodash._baseassign": "^3.0.0",
+            "lodash._basecreate": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0"
           }
         },
         "lodash.isarguments": {
@@ -950,9 +950,9 @@
           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
           "dev": true,
           "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
           }
         },
         "minimatch": {
@@ -961,7 +961,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -991,7 +991,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "path-is-absolute": {
@@ -1006,7 +1006,7 @@
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         },
         "wrappy": {
@@ -1034,11 +1034,11 @@
       "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
       "dev": true,
       "requires": {
-        "formatio": "1.2.0",
-        "just-extend": "1.1.27",
-        "lolex": "1.6.0",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
+        "formatio": "^1.2.0",
+        "just-extend": "^1.1.26",
+        "lolex": "^1.6.0",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
       },
       "dependencies": {
         "lolex": {
@@ -1055,33 +1055,33 @@
       "integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
       "dev": true,
       "requires": {
-        "archy": "1.0.0",
-        "arrify": "1.0.1",
-        "caching-transform": "1.0.1",
-        "convert-source-map": "1.5.1",
-        "debug-log": "1.0.1",
-        "default-require-extensions": "1.0.0",
-        "find-cache-dir": "0.1.1",
-        "find-up": "2.1.0",
-        "foreground-child": "1.5.6",
-        "glob": "7.1.2",
-        "istanbul-lib-coverage": "1.1.1",
-        "istanbul-lib-hook": "1.1.0",
-        "istanbul-lib-instrument": "1.9.1",
-        "istanbul-lib-report": "1.1.2",
-        "istanbul-lib-source-maps": "1.2.2",
-        "istanbul-reports": "1.1.3",
-        "md5-hex": "1.3.0",
-        "merge-source-map": "1.0.4",
-        "micromatch": "2.3.11",
-        "mkdirp": "0.5.1",
-        "resolve-from": "2.0.0",
-        "rimraf": "2.6.2",
-        "signal-exit": "3.0.2",
-        "spawn-wrap": "1.4.2",
-        "test-exclude": "4.1.1",
-        "yargs": "10.0.3",
-        "yargs-parser": "8.0.0"
+        "archy": "^1.0.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^1.0.0",
+        "convert-source-map": "^1.3.0",
+        "debug-log": "^1.0.1",
+        "default-require-extensions": "^1.0.0",
+        "find-cache-dir": "^0.1.1",
+        "find-up": "^2.1.0",
+        "foreground-child": "^1.5.3",
+        "glob": "^7.0.6",
+        "istanbul-lib-coverage": "^1.1.1",
+        "istanbul-lib-hook": "^1.1.0",
+        "istanbul-lib-instrument": "^1.9.1",
+        "istanbul-lib-report": "^1.1.2",
+        "istanbul-lib-source-maps": "^1.2.2",
+        "istanbul-reports": "^1.1.3",
+        "md5-hex": "^1.2.0",
+        "merge-source-map": "^1.0.2",
+        "micromatch": "^2.3.11",
+        "mkdirp": "^0.5.0",
+        "resolve-from": "^2.0.0",
+        "rimraf": "^2.5.4",
+        "signal-exit": "^3.0.1",
+        "spawn-wrap": "^1.4.2",
+        "test-exclude": "^4.1.1",
+        "yargs": "^10.0.3",
+        "yargs-parser": "^8.0.0"
       },
       "dependencies": {
         "align-text": {
@@ -1089,9 +1089,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2",
-            "longest": "1.0.1",
-            "repeat-string": "1.6.1"
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
           }
         },
         "amdefine": {
@@ -1114,7 +1114,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "default-require-extensions": "1.0.0"
+            "default-require-extensions": "^1.0.0"
           }
         },
         "archy": {
@@ -1127,7 +1127,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "arr-flatten": {
@@ -1155,9 +1155,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-generator": {
@@ -1165,14 +1165,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.4",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.6",
+            "trim-right": "^1.0.1"
           }
         },
         "babel-messages": {
@@ -1180,7 +1180,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-runtime": {
@@ -1188,8 +1188,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-js": "2.5.3",
-            "regenerator-runtime": "0.11.1"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
           }
         },
         "babel-template": {
@@ -1197,11 +1197,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -1209,15 +1209,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -1225,10 +1225,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babylon": {
@@ -1246,7 +1246,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -1255,9 +1255,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "builtin-modules": {
@@ -1270,9 +1270,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-hex": "1.3.0",
-            "mkdirp": "0.5.1",
-            "write-file-atomic": "1.3.4"
+            "md5-hex": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "write-file-atomic": "^1.1.4"
           }
         },
         "camelcase": {
@@ -1287,8 +1287,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "0.1.4",
-            "lazy-cache": "1.0.4"
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
           }
         },
         "chalk": {
@@ -1296,11 +1296,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "cliui": {
@@ -1309,8 +1309,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           },
           "dependencies": {
@@ -1352,8 +1352,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.1",
-            "which": "1.3.0"
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
           }
         },
         "debug": {
@@ -1379,7 +1379,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-bom": "2.0.0"
+            "strip-bom": "^2.0.0"
           }
         },
         "detect-indent": {
@@ -1387,7 +1387,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "error-ex": {
@@ -1395,7 +1395,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-arrayish": "0.2.1"
+            "is-arrayish": "^0.2.1"
           }
         },
         "escape-string-regexp": {
@@ -1413,13 +1413,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           },
           "dependencies": {
             "cross-spawn": {
@@ -1427,9 +1427,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "4.1.1",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
               }
             }
           }
@@ -1439,7 +1439,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "expand-range": {
@@ -1447,7 +1447,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fill-range": "2.2.3"
+            "fill-range": "^2.1.0"
           }
         },
         "extglob": {
@@ -1455,7 +1455,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "filename-regex": {
@@ -1468,11 +1468,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "find-cache-dir": {
@@ -1480,9 +1480,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pkg-dir": "1.0.0"
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
           }
         },
         "find-up": {
@@ -1490,7 +1490,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "for-in": {
@@ -1503,7 +1503,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "for-in": "1.0.2"
+            "for-in": "^1.0.1"
           }
         },
         "foreground-child": {
@@ -1511,8 +1511,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "4.0.2",
-            "signal-exit": "3.0.2"
+            "cross-spawn": "^4",
+            "signal-exit": "^3.0.0"
           }
         },
         "fs.realpath": {
@@ -1535,12 +1535,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-base": {
@@ -1548,8 +1548,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "glob-parent": {
@@ -1557,7 +1557,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "globals": {
@@ -1575,10 +1575,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.29"
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
           },
           "dependencies": {
             "source-map": {
@@ -1586,7 +1586,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -1596,7 +1596,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "has-flag": {
@@ -1619,8 +1619,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -1633,7 +1633,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "invert-kv": {
@@ -1656,7 +1656,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtin-modules": "1.1.1"
+            "builtin-modules": "^1.0.0"
           }
         },
         "is-dotfile": {
@@ -1669,7 +1669,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-primitive": "2.0.0"
+            "is-primitive": "^2.0.0"
           }
         },
         "is-extendable": {
@@ -1687,7 +1687,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -1695,7 +1695,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-glob": {
@@ -1703,7 +1703,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "is-number": {
@@ -1711,7 +1711,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-posix-bracket": {
@@ -1762,7 +1762,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "append-transform": "0.4.0"
+            "append-transform": "^0.4.0"
           }
         },
         "istanbul-lib-instrument": {
@@ -1770,13 +1770,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-generator": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "istanbul-lib-coverage": "1.1.1",
-            "semver": "5.4.1"
+            "babel-generator": "^6.18.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.18.0",
+            "babel-types": "^6.18.0",
+            "babylon": "^6.18.0",
+            "istanbul-lib-coverage": "^1.1.1",
+            "semver": "^5.3.0"
           }
         },
         "istanbul-lib-report": {
@@ -1784,10 +1784,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "1.1.1",
-            "mkdirp": "0.5.1",
-            "path-parse": "1.0.5",
-            "supports-color": "3.2.3"
+            "istanbul-lib-coverage": "^1.1.1",
+            "mkdirp": "^0.5.1",
+            "path-parse": "^1.0.5",
+            "supports-color": "^3.1.2"
           },
           "dependencies": {
             "supports-color": {
@@ -1795,7 +1795,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "has-flag": "1.0.0"
+                "has-flag": "^1.0.0"
               }
             }
           }
@@ -1805,11 +1805,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "3.1.0",
-            "istanbul-lib-coverage": "1.1.1",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "source-map": "0.5.7"
+            "debug": "^3.1.0",
+            "istanbul-lib-coverage": "^1.1.1",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.6.1",
+            "source-map": "^0.5.3"
           },
           "dependencies": {
             "debug": {
@@ -1827,7 +1827,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "handlebars": "4.0.11"
+            "handlebars": "^4.0.3"
           }
         },
         "js-tokens": {
@@ -1845,7 +1845,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "lazy-cache": {
@@ -1859,7 +1859,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
         },
         "load-json-file": {
@@ -1867,11 +1867,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "locate-path": {
@@ -1879,8 +1879,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           },
           "dependencies": {
             "path-exists": {
@@ -1905,7 +1905,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "lru-cache": {
@@ -1913,8 +1913,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "md5-hex": {
@@ -1922,7 +1922,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-o-matic": "0.1.1"
+            "md5-o-matic": "^0.1.1"
           }
         },
         "md5-o-matic": {
@@ -1935,7 +1935,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mimic-fn": "1.1.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "merge-source-map": {
@@ -1943,7 +1943,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "source-map": "0.5.7"
+            "source-map": "^0.5.6"
           }
         },
         "micromatch": {
@@ -1951,19 +1951,19 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         },
         "mimic-fn": {
@@ -1976,7 +1976,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -2002,10 +2002,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "normalize-path": {
@@ -2013,7 +2013,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "1.1.0"
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "npm-run-path": {
@@ -2021,7 +2021,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-key": "2.0.1"
+            "path-key": "^2.0.0"
           }
         },
         "number-is-nan": {
@@ -2039,8 +2039,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
           }
         },
         "once": {
@@ -2048,7 +2048,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "optimist": {
@@ -2056,8 +2056,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
           }
         },
         "os-homedir": {
@@ -2070,9 +2070,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
           }
         },
         "p-finally": {
@@ -2090,7 +2090,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-limit": "1.1.0"
+            "p-limit": "^1.1.0"
           }
         },
         "parse-glob": {
@@ -2098,10 +2098,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "parse-json": {
@@ -2109,7 +2109,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -2117,7 +2117,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-is-absolute": {
@@ -2140,9 +2140,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -2160,7 +2160,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "pkg-dir": {
@@ -2168,7 +2168,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           },
           "dependencies": {
             "find-up": {
@@ -2176,8 +2176,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             }
           }
@@ -2197,8 +2197,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -2206,7 +2206,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -2214,7 +2214,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -2224,7 +2224,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -2234,9 +2234,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -2244,8 +2244,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           },
           "dependencies": {
             "find-up": {
@@ -2253,8 +2253,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             }
           }
@@ -2269,7 +2269,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-equal-shallow": "0.1.3"
+            "is-equal-shallow": "^0.1.3"
           }
         },
         "remove-trailing-separator": {
@@ -2292,7 +2292,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "require-directory": {
@@ -2316,7 +2316,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "0.1.4"
+            "align-text": "^0.1.1"
           }
         },
         "rimraf": {
@@ -2324,7 +2324,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "semver": {
@@ -2342,7 +2342,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "shebang-regex": "1.0.0"
+            "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
@@ -2370,12 +2370,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "foreground-child": "1.5.6",
-            "mkdirp": "0.5.1",
-            "os-homedir": "1.0.2",
-            "rimraf": "2.6.2",
-            "signal-exit": "3.0.2",
-            "which": "1.3.0"
+            "foreground-child": "^1.5.6",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.2",
+            "which": "^1.3.0"
           }
         },
         "spdx-correct": {
@@ -2383,7 +2383,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-license-ids": "1.2.2"
+            "spdx-license-ids": "^1.0.2"
           }
         },
         "spdx-expression-parse": {
@@ -2401,8 +2401,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -2420,7 +2420,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -2430,7 +2430,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -2438,7 +2438,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-eof": {
@@ -2456,11 +2456,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arrify": "1.0.1",
-            "micromatch": "2.3.11",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "require-main-filename": "1.0.1"
+            "arrify": "^1.0.1",
+            "micromatch": "^2.3.11",
+            "object-assign": "^4.1.0",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
           }
         },
         "to-fast-properties": {
@@ -2479,9 +2479,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "yargs": {
@@ -2490,9 +2490,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
                 "window-size": "0.1.0"
               }
             }
@@ -2509,8 +2509,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
           }
         },
         "which": {
@@ -2518,7 +2518,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "which-module": {
@@ -2542,8 +2542,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "string-width": {
@@ -2551,9 +2551,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -2568,9 +2568,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
           }
         },
         "y18n": {
@@ -2588,18 +2588,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "8.0.0"
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^8.0.0"
           },
           "dependencies": {
             "cliui": {
@@ -2607,9 +2607,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
               },
               "dependencies": {
                 "string-width": {
@@ -2617,9 +2617,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
                   }
                 }
               }
@@ -2631,7 +2631,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           },
           "dependencies": {
             "camelcase": {
@@ -2648,7 +2648,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "ora": {
@@ -2656,10 +2656,10 @@
       "resolved": "https://registry.npmjs.org/ora/-/ora-1.4.0.tgz",
       "integrity": "sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==",
       "requires": {
-        "chalk": "2.3.0",
-        "cli-cursor": "2.1.0",
-        "cli-spinners": "1.1.0",
-        "log-symbols": "2.2.0"
+        "chalk": "^2.1.0",
+        "cli-cursor": "^2.1.0",
+        "cli-spinners": "^1.0.1",
+        "log-symbols": "^2.1.0"
       }
     },
     "os-tmpdir": {
@@ -2687,8 +2687,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "samsam": {
@@ -2708,13 +2708,13 @@
       "integrity": "sha512-BEa593xl+IkIc94nKo0O0LauQC/gQy8Gyv4DkzPwF/9DweC5phr1y+42zibCpn9abfkdHxt9r8AhD0R6u9DE/Q==",
       "dev": true,
       "requires": {
-        "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+        "diff": "^3.1.0",
         "formatio": "1.2.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.3.1",
-        "nise": "1.2.0",
-        "supports-color": "5.1.0",
-        "type-detect": "4.0.7"
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.2.0",
+        "nise": "^1.2.0",
+        "supports-color": "^5.1.0",
+        "type-detect": "^4.0.5"
       },
       "dependencies": {
         "has-flag": {
@@ -2729,7 +2729,7 @@
           "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -2751,7 +2751,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "tmp-promise": {
@@ -2760,7 +2760,7 @@
       "integrity": "sha512-76r7LZhAvRJ3kLD/xrPSEGb3aq0tirzMLJKhcchKSkQIiEgXB+RouC0ygReuZX+oiA64taGo+j+1gHTKSG8/Mg==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
+        "bluebird": "^3.5.0",
         "tmp": "0.0.33"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -746,7 +746,7 @@
     "mocha": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ansi-styles": {
@@ -30,7 +30,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.1"
       }
     },
     "argparse": {
@@ -38,7 +38,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "asn1": {
@@ -84,7 +84,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "bluebird": {
@@ -99,7 +99,7 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "brace-expansion": {
@@ -108,7 +108,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -129,9 +129,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
       }
     },
     "cli-cursor": {
@@ -139,7 +139,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-spinners": {
@@ -158,7 +158,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -172,7 +172,7 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -207,11 +207,11 @@
       "integrity": "sha512-FAzXwiDOYLGDWH+zgoIA+8GbWv50hlx+kpEJyvzLKOdnIBv9uWoVl4DhqGgyUHpiRjAlF8KYZSipWXYtllWH6Q==",
       "dev": true,
       "requires": {
-        "js-yaml": "^3.6.1",
-        "lcov-parse": "^0.0.10",
-        "log-driver": "^1.2.5",
-        "minimist": "^1.2.0",
-        "request": "^2.79.0"
+        "js-yaml": "3.11.0",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.7",
+        "minimist": "1.2.0",
+        "request": "2.85.0"
       }
     },
     "cryptiles": {
@@ -220,7 +220,7 @@
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "5.x.x"
+        "boom": "5.2.0"
       },
       "dependencies": {
         "boom": {
@@ -229,7 +229,7 @@
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         }
       }
@@ -240,7 +240,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "debug": {
@@ -271,7 +271,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "escape-string-regexp": {
@@ -325,9 +325,9 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.18"
       }
     },
     "fs-extra": {
@@ -335,9 +335,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
       }
     },
     "fs.realpath": {
@@ -352,7 +352,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
@@ -361,12 +361,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -392,8 +392,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has-flag": {
@@ -407,10 +407,10 @@
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "4.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "sntp": "2.x.x"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
       }
     },
     "he": {
@@ -431,9 +431,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
       }
     },
     "inflight": {
@@ -442,8 +442,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -480,8 +480,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
       }
     },
     "jsbn": {
@@ -519,7 +519,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsprim": {
@@ -568,7 +568,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "2.4.1"
       }
     },
     "lokijs": {
@@ -594,7 +594,7 @@
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimic-fn": {
@@ -608,7 +608,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -677,7 +677,7 @@
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -705,11 +705,11 @@
       "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "just-extend": "^1.1.27",
-        "lolex": "^2.3.2",
-        "path-to-regexp": "^1.7.0",
-        "text-encoding": "^0.6.4"
+        "@sinonjs/formatio": "2.0.0",
+        "just-extend": "1.1.27",
+        "lolex": "2.4.1",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
       }
     },
     "nyc": {
@@ -718,33 +718,33 @@
       "integrity": "sha512-gBt7qwsR1vryYfglVjQRx1D+AtMZW5NbUKxb+lZe8SN8KsheGCPGWEsSC9AGQG+r2+te1+10uPHUCahuqm1nGQ==",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "arrify": "^1.0.1",
-        "caching-transform": "^1.0.0",
-        "convert-source-map": "^1.5.1",
-        "debug-log": "^1.0.1",
-        "default-require-extensions": "^1.0.0",
-        "find-cache-dir": "^0.1.1",
-        "find-up": "^2.1.0",
-        "foreground-child": "^1.5.3",
-        "glob": "^7.0.6",
-        "istanbul-lib-coverage": "^1.1.2",
-        "istanbul-lib-hook": "^1.1.0",
-        "istanbul-lib-instrument": "^1.10.0",
-        "istanbul-lib-report": "^1.1.3",
-        "istanbul-lib-source-maps": "^1.2.3",
-        "istanbul-reports": "^1.4.0",
-        "md5-hex": "^1.2.0",
-        "merge-source-map": "^1.1.0",
-        "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.0",
-        "resolve-from": "^2.0.0",
-        "rimraf": "^2.6.2",
-        "signal-exit": "^3.0.1",
-        "spawn-wrap": "^1.4.2",
-        "test-exclude": "^4.2.0",
+        "archy": "1.0.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.5.1",
+        "debug-log": "1.0.1",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "2.1.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.2",
+        "istanbul-lib-coverage": "1.2.0",
+        "istanbul-lib-hook": "1.1.0",
+        "istanbul-lib-instrument": "1.10.1",
+        "istanbul-lib-report": "1.1.3",
+        "istanbul-lib-source-maps": "1.2.3",
+        "istanbul-reports": "1.4.0",
+        "md5-hex": "1.3.0",
+        "merge-source-map": "1.1.0",
+        "micromatch": "3.1.10",
+        "mkdirp": "0.5.1",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.6.2",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.4.2",
+        "test-exclude": "4.2.1",
         "yargs": "11.1.0",
-        "yargs-parser": "^8.0.0"
+        "yargs-parser": "8.1.0"
       },
       "dependencies": {
         "align-text": {
@@ -856,14 +856,14 @@
           "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
           "dev": true,
           "requires": {
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "detect-indent": "^4.0.0",
-            "jsesc": "^1.3.0",
-            "lodash": "^4.17.4",
-            "source-map": "^0.5.7",
-            "trim-right": "^1.0.1"
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.10",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
           }
         },
         "babel-messages": {
@@ -945,13 +945,13 @@
           "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
           "dev": true,
           "requires": {
-            "cache-base": "^1.0.1",
-            "class-utils": "^0.3.5",
-            "component-emitter": "^1.2.1",
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.1",
-            "mixin-deep": "^1.2.0",
-            "pascalcase": "^0.1.1"
+            "cache-base": "1.0.1",
+            "class-utils": "0.3.6",
+            "component-emitter": "1.2.1",
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "mixin-deep": "1.3.1",
+            "pascalcase": "0.1.1"
           },
           "dependencies": {
             "define-property": {
@@ -960,7 +960,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "is-accessor-descriptor": {
@@ -969,7 +969,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -978,7 +978,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -987,9 +987,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "kind-of": {
@@ -1006,7 +1006,7 @@
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -1016,16 +1016,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -1034,7 +1034,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -1051,15 +1051,15 @@
           "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
           "dev": true,
           "requires": {
-            "collection-visit": "^1.0.0",
-            "component-emitter": "^1.2.1",
-            "get-value": "^2.0.6",
-            "has-value": "^1.0.0",
-            "isobject": "^3.0.1",
-            "set-value": "^2.0.0",
-            "to-object-path": "^0.3.0",
-            "union-value": "^1.0.0",
-            "unset-value": "^1.0.0"
+            "collection-visit": "1.0.0",
+            "component-emitter": "1.2.1",
+            "get-value": "2.0.6",
+            "has-value": "1.0.0",
+            "isobject": "3.0.1",
+            "set-value": "2.0.0",
+            "to-object-path": "0.3.0",
+            "union-value": "1.0.0",
+            "unset-value": "1.0.0"
           }
         },
         "caching-transform": {
@@ -1110,10 +1110,10 @@
           "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
           "dev": true,
           "requires": {
-            "arr-union": "^3.1.0",
-            "define-property": "^0.2.5",
-            "isobject": "^3.0.0",
-            "static-extend": "^0.1.1"
+            "arr-union": "3.1.0",
+            "define-property": "0.2.5",
+            "isobject": "3.0.1",
+            "static-extend": "0.1.2"
           },
           "dependencies": {
             "define-property": {
@@ -1122,7 +1122,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             }
           }
@@ -1160,8 +1160,8 @@
           "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
           "dev": true,
           "requires": {
-            "map-visit": "^1.0.0",
-            "object-visit": "^1.0.0"
+            "map-visit": "1.0.0",
+            "object-visit": "1.0.1"
           }
         },
         "commondir": {
@@ -1252,8 +1252,8 @@
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.2",
-            "isobject": "^3.0.1"
+            "is-descriptor": "1.0.2",
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "is-accessor-descriptor": {
@@ -1262,7 +1262,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -1271,7 +1271,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -1280,9 +1280,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "kind-of": {
@@ -1357,13 +1357,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -1372,7 +1372,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -1381,7 +1381,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -1392,8 +1392,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -1402,7 +1402,7 @@
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
-                "is-plain-object": "^2.0.4"
+                "is-plain-object": "2.0.4"
               }
             }
           }
@@ -1413,14 +1413,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -1429,7 +1429,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -1438,7 +1438,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -1447,7 +1447,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -1456,7 +1456,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -1465,9 +1465,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "kind-of": {
@@ -1484,10 +1484,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -1496,7 +1496,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -1543,7 +1543,7 @@
           "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
           "dev": true,
           "requires": {
-            "map-cache": "^0.2.2"
+            "map-cache": "0.2.2"
           }
         },
         "fs.realpath": {
@@ -1640,9 +1640,9 @@
           "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.6",
-            "has-values": "^1.0.0",
-            "isobject": "^3.0.0"
+            "get-value": "2.0.6",
+            "has-values": "1.0.0",
+            "isobject": "3.0.1"
           }
         },
         "has-values": {
@@ -1651,8 +1651,8 @@
           "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
           "dev": true,
           "requires": {
-            "is-number": "^3.0.0",
-            "kind-of": "^4.0.0"
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -1661,7 +1661,7 @@
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -1700,7 +1700,7 @@
           "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
           "dev": true,
           "requires": {
-            "loose-envify": "^1.0.0"
+            "loose-envify": "1.3.1"
           }
         },
         "invert-kv": {
@@ -1715,7 +1715,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-arrayish": {
@@ -1745,7 +1745,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-descriptor": {
@@ -1754,9 +1754,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           },
           "dependencies": {
             "kind-of": {
@@ -1794,7 +1794,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-odd": {
@@ -1803,7 +1803,7 @@
           "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
           "dev": true,
           "requires": {
-            "is-number": "^4.0.0"
+            "is-number": "4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -1820,7 +1820,7 @@
           "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
           "dev": true,
           "requires": {
-            "isobject": "^3.0.1"
+            "isobject": "3.0.1"
           }
         },
         "is-stream": {
@@ -1880,13 +1880,13 @@
           "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
           "dev": true,
           "requires": {
-            "babel-generator": "^6.18.0",
-            "babel-template": "^6.16.0",
-            "babel-traverse": "^6.18.0",
-            "babel-types": "^6.18.0",
-            "babylon": "^6.18.0",
-            "istanbul-lib-coverage": "^1.2.0",
-            "semver": "^5.3.0"
+            "babel-generator": "6.26.1",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "istanbul-lib-coverage": "1.2.0",
+            "semver": "5.5.0"
           }
         },
         "istanbul-lib-report": {
@@ -1895,10 +1895,10 @@
           "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "^1.1.2",
-            "mkdirp": "^0.5.1",
-            "path-parse": "^1.0.5",
-            "supports-color": "^3.1.2"
+            "istanbul-lib-coverage": "1.2.0",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "supports-color": "3.2.3"
           },
           "dependencies": {
             "supports-color": {
@@ -1918,11 +1918,11 @@
           "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
           "dev": true,
           "requires": {
-            "debug": "^3.1.0",
-            "istanbul-lib-coverage": "^1.1.2",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.6.1",
-            "source-map": "^0.5.3"
+            "debug": "3.1.0",
+            "istanbul-lib-coverage": "1.2.0",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "source-map": "0.5.7"
           },
           "dependencies": {
             "debug": {
@@ -1942,7 +1942,7 @@
           "integrity": "sha512-OPzVo1fPZ2H+owr8q/LYKLD+vquv9Pj4F+dj808MdHbuQLD7S4ACRjcX+0Tne5Vxt2lxXvdZaL7v+FOOAV281w==",
           "dev": true,
           "requires": {
-            "handlebars": "^4.0.3"
+            "handlebars": "4.0.11"
           }
         },
         "js-tokens": {
@@ -2040,8 +2040,8 @@
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         },
         "map-cache": {
@@ -2056,7 +2056,7 @@
           "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
           "dev": true,
           "requires": {
-            "object-visit": "^1.0.0"
+            "object-visit": "1.0.1"
           }
         },
         "md5-hex": {
@@ -2089,7 +2089,7 @@
           "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
           "dev": true,
           "requires": {
-            "source-map": "^0.6.1"
+            "source-map": "0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -2106,19 +2106,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2156,8 +2156,8 @@
           "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.2",
-            "is-extendable": "^1.0.1"
+            "for-in": "1.0.2",
+            "is-extendable": "1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -2166,7 +2166,7 @@
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
-                "is-plain-object": "^2.0.4"
+                "is-plain-object": "2.0.4"
               }
             }
           }
@@ -2192,18 +2192,18 @@
           "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "fragment-cache": "^0.2.1",
-            "is-odd": "^2.0.0",
-            "is-windows": "^1.0.2",
-            "kind-of": "^6.0.2",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "fragment-cache": "0.2.1",
+            "is-odd": "2.0.0",
+            "is-windows": "1.0.2",
+            "kind-of": "6.0.2",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2253,9 +2253,9 @@
           "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
           "dev": true,
           "requires": {
-            "copy-descriptor": "^0.1.0",
-            "define-property": "^0.2.5",
-            "kind-of": "^3.0.3"
+            "copy-descriptor": "0.1.1",
+            "define-property": "0.2.5",
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "define-property": {
@@ -2264,7 +2264,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             }
           }
@@ -2275,7 +2275,7 @@
           "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
           "dev": true,
           "requires": {
-            "isobject": "^3.0.0"
+            "isobject": "3.0.1"
           }
         },
         "object.pick": {
@@ -2284,7 +2284,7 @@
           "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
           "dev": true,
           "requires": {
-            "isobject": "^3.0.1"
+            "isobject": "3.0.1"
           }
         },
         "once": {
@@ -2335,7 +2335,7 @@
           "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
           "dev": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -2505,8 +2505,8 @@
           "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
           "dev": true,
           "requires": {
-            "extend-shallow": "^3.0.2",
-            "safe-regex": "^1.1.0"
+            "extend-shallow": "3.0.2",
+            "safe-regex": "1.1.0"
           }
         },
         "repeat-element": {
@@ -2585,7 +2585,7 @@
           "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
           "dev": true,
           "requires": {
-            "ret": "~0.1.10"
+            "ret": "0.1.15"
           }
         },
         "semver": {
@@ -2606,10 +2606,10 @@
           "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.3",
-            "split-string": "^3.0.1"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "split-string": "3.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -2618,7 +2618,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -2656,14 +2656,14 @@
           "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
           "dev": true,
           "requires": {
-            "base": "^0.11.1",
-            "debug": "^2.2.0",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "map-cache": "^0.2.2",
-            "source-map": "^0.5.6",
-            "source-map-resolve": "^0.5.0",
-            "use": "^3.1.0"
+            "base": "0.11.2",
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "map-cache": "0.2.2",
+            "source-map": "0.5.7",
+            "source-map-resolve": "0.5.1",
+            "use": "3.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -2672,7 +2672,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -2681,7 +2681,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -2692,9 +2692,9 @@
           "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
           "dev": true,
           "requires": {
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.0",
-            "snapdragon-util": "^3.0.1"
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "snapdragon-util": "3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -2703,7 +2703,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "is-accessor-descriptor": {
@@ -2712,7 +2712,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -2721,7 +2721,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -2730,9 +2730,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "kind-of": {
@@ -2749,7 +2749,7 @@
           "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^3.2.0"
+            "kind-of": "3.2.2"
           }
         },
         "source-map": {
@@ -2764,11 +2764,11 @@
           "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
           "dev": true,
           "requires": {
-            "atob": "^2.0.0",
-            "decode-uri-component": "^0.2.0",
-            "resolve-url": "^0.2.1",
-            "source-map-url": "^0.4.0",
-            "urix": "^0.1.0"
+            "atob": "2.1.1",
+            "decode-uri-component": "0.2.0",
+            "resolve-url": "0.2.1",
+            "source-map-url": "0.4.0",
+            "urix": "0.1.0"
           }
         },
         "source-map-url": {
@@ -2797,8 +2797,8 @@
           "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "dev": true,
           "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
+            "spdx-expression-parse": "3.0.0",
+            "spdx-license-ids": "3.0.0"
           }
         },
         "spdx-exceptions": {
@@ -2813,8 +2813,8 @@
           "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "dev": true,
           "requires": {
-            "spdx-exceptions": "^2.1.0",
-            "spdx-license-ids": "^3.0.0"
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "3.0.0"
           }
         },
         "spdx-license-ids": {
@@ -2829,7 +2829,7 @@
           "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
           "dev": true,
           "requires": {
-            "extend-shallow": "^3.0.0"
+            "extend-shallow": "3.0.2"
           }
         },
         "static-extend": {
@@ -2838,8 +2838,8 @@
           "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
           "dev": true,
           "requires": {
-            "define-property": "^0.2.5",
-            "object-copy": "^0.1.0"
+            "define-property": "0.2.5",
+            "object-copy": "0.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -2848,7 +2848,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             }
           }
@@ -2916,11 +2916,11 @@
           "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
           "dev": true,
           "requires": {
-            "arrify": "^1.0.1",
-            "micromatch": "^3.1.8",
-            "object-assign": "^4.1.0",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1"
+            "arrify": "1.0.1",
+            "micromatch": "3.1.10",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
           }
         },
         "to-fast-properties": {
@@ -2935,7 +2935,7 @@
           "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "to-regex": {
@@ -2944,10 +2944,10 @@
           "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
           "dev": true,
           "requires": {
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "regex-not": "^1.0.2",
-            "safe-regex": "^1.1.0"
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "regex-not": "1.0.2",
+            "safe-regex": "1.1.0"
           }
         },
         "to-regex-range": {
@@ -2956,8 +2956,8 @@
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
           "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1"
           }
         },
         "trim-right": {
@@ -3006,10 +3006,10 @@
           "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
           "dev": true,
           "requires": {
-            "arr-union": "^3.1.0",
-            "get-value": "^2.0.6",
-            "is-extendable": "^0.1.1",
-            "set-value": "^0.4.3"
+            "arr-union": "3.1.0",
+            "get-value": "2.0.6",
+            "is-extendable": "0.1.1",
+            "set-value": "0.4.3"
           },
           "dependencies": {
             "extend-shallow": {
@@ -3018,7 +3018,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "set-value": {
@@ -3027,10 +3027,10 @@
               "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
               "dev": true,
               "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.1",
-                "to-object-path": "^0.3.0"
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "to-object-path": "0.3.0"
               }
             }
           }
@@ -3041,8 +3041,8 @@
           "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
           "dev": true,
           "requires": {
-            "has-value": "^0.3.1",
-            "isobject": "^3.0.0"
+            "has-value": "0.3.1",
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "has-value": {
@@ -3051,9 +3051,9 @@
               "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
               "dev": true,
               "requires": {
-                "get-value": "^2.0.3",
-                "has-values": "^0.1.4",
-                "isobject": "^2.0.0"
+                "get-value": "2.0.6",
+                "has-values": "0.1.4",
+                "isobject": "2.1.0"
               },
               "dependencies": {
                 "isobject": {
@@ -3087,7 +3087,7 @@
           "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.2"
+            "kind-of": "6.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -3104,8 +3104,8 @@
           "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
           "dev": true,
           "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
           }
         },
         "which": {
@@ -3203,18 +3203,18 @@
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           },
           "dependencies": {
             "ansi-regex": {
@@ -3235,9 +3235,9 @@
               "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
               "dev": true,
               "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "wrap-ansi": "2.1.0"
               }
             },
             "strip-ansi": {
@@ -3246,7 +3246,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             },
             "yargs-parser": {
@@ -3255,7 +3255,7 @@
               "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
               "dev": true,
               "requires": {
-                "camelcase": "^4.1.0"
+                "camelcase": "4.1.0"
               }
             }
           }
@@ -3266,7 +3266,7 @@
           "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           },
           "dependencies": {
             "camelcase": {
@@ -3291,7 +3291,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -3299,7 +3299,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "ora": {
@@ -3307,10 +3307,10 @@
       "resolved": "https://registry.npmjs.org/ora/-/ora-1.4.0.tgz",
       "integrity": "sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==",
       "requires": {
-        "chalk": "^2.1.0",
-        "cli-cursor": "^2.1.0",
-        "cli-spinners": "^1.0.1",
-        "log-symbols": "^2.1.0"
+        "chalk": "2.4.1",
+        "cli-cursor": "2.1.0",
+        "cli-spinners": "1.3.1",
+        "log-symbols": "2.2.0"
       }
     },
     "os-homedir": {
@@ -3368,28 +3368,28 @@
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
       }
     },
     "restore-cursor": {
@@ -3397,8 +3397,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "safe-buffer": {
@@ -3424,13 +3424,13 @@
       "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "diff": "^3.1.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.2.0",
-        "nise": "^1.2.0",
-        "supports-color": "^5.1.0",
-        "type-detect": "^4.0.5"
+        "@sinonjs/formatio": "2.0.0",
+        "diff": "3.2.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.4.1",
+        "nise": "1.3.3",
+        "supports-color": "5.4.0",
+        "type-detect": "4.0.8"
       }
     },
     "sntp": {
@@ -3439,7 +3439,7 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "sprintf-js": {
@@ -3453,14 +3453,14 @@
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       }
     },
     "stringstream": {
@@ -3474,7 +3474,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "text-encoding": {
@@ -3489,7 +3489,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "tmp-promise": {
@@ -3498,7 +3498,7 @@
       "integrity": "sha512-76r7LZhAvRJ3kLD/xrPSEGb3aq0tirzMLJKhcchKSkQIiEgXB+RouC0ygReuZX+oiA64taGo+j+1gHTKSG8/Mg==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.0",
+        "bluebird": "3.5.1",
         "tmp": "0.0.33"
       }
     },
@@ -3508,7 +3508,7 @@
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       }
     },
     "tunnel-agent": {
@@ -3517,7 +3517,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -3549,9 +3549,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "wrappy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,20 +4,87 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
     "ansi-styles": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
         "color-convert": "^1.9.0"
       }
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
       }
     },
     "bluebird": {
@@ -26,29 +93,45 @@
       "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
       "dev": true
     },
-    "chalk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "dev": true,
       "requires": {
-        "ansi-styles": "^3.1.0",
+        "hoek": "4.x.x"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
-        "supports-color": "^4.0.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "requires": {
-            "has-flag": "^2.0.0"
-          }
-        }
+        "supports-color": "^5.3.0"
       }
     },
     "cli-cursor": {
@@ -60,9 +143,15 @@
       }
     },
     "cli-spinners": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
-      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
+      "integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg=="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.1",
@@ -77,10 +166,25 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "config": {
       "version": "1.30.0",
@@ -89,24 +193,18 @@
       "requires": {
         "json5": "0.4.0",
         "os-homedir": "1.0.2"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-        }
       }
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
     "coveralls": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
-      "integrity": "sha1-Iu9zAzBTgIDSm4wVHckUav3oipk=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.1.tgz",
+      "integrity": "sha512-FAzXwiDOYLGDWH+zgoIA+8GbWv50hlx+kpEJyvzLKOdnIBv9uWoVl4DhqGgyUHpiRjAlF8KYZSipWXYtllWH6Q==",
       "dev": true,
       "requires": {
         "js-yaml": "^3.6.1",
@@ -114,530 +212,71 @@
         "log-driver": "^1.2.5",
         "minimist": "^1.2.0",
         "request": "^2.79.0"
+      }
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "dev": true,
+      "requires": {
+        "boom": "5.x.x"
       },
       "dependencies": {
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          },
-          "dependencies": {
-            "argparse": {
-              "version": "1.0.9",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-              "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-              "dev": true,
-              "requires": {
-                "sprintf-js": "~1.0.2"
-              },
-              "dependencies": {
-                "sprintf-js": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-                  "dev": true
-                }
-              }
-            },
-            "esprima": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-              "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
-              "dev": true
-            }
-          }
-        },
-        "lcov-parse": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-          "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
-          "dev": true
-        },
-        "log-driver": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
-          "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.83.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-          "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "hawk": "~6.0.2",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "stringstream": "~0.0.5",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
-          },
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-              "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-              "dev": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-              "dev": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-              "dev": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-              "dev": true,
-              "requires": {
-                "delayed-stream": "~1.0.0"
-              },
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-                  "dev": true
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-              "dev": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-              "dev": true
-            },
-            "form-data": {
-              "version": "2.3.1",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-              "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-              "dev": true,
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.5",
-                "mime-types": "^2.1.12"
-              },
-              "dependencies": {
-                "asynckit": {
-                  "version": "0.4.0",
-                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                  "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-                  "dev": true
-                }
-              }
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-              "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-              "dev": true,
-              "requires": {
-                "ajv": "^5.1.0",
-                "har-schema": "^2.0.0"
-              },
-              "dependencies": {
-                "ajv": {
-                  "version": "5.2.3",
-                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-                  "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
-                  "dev": true,
-                  "requires": {
-                    "co": "^4.6.0",
-                    "fast-deep-equal": "^1.0.0",
-                    "json-schema-traverse": "^0.3.0",
-                    "json-stable-stringify": "^1.0.1"
-                  },
-                  "dependencies": {
-                    "co": {
-                      "version": "4.6.0",
-                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-                      "dev": true
-                    },
-                    "fast-deep-equal": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-                      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
-                      "dev": true
-                    },
-                    "json-schema-traverse": {
-                      "version": "0.3.1",
-                      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-                      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-                      "dev": true
-                    },
-                    "json-stable-stringify": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-                      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-                      "dev": true,
-                      "requires": {
-                        "jsonify": "~0.0.0"
-                      },
-                      "dependencies": {
-                        "jsonify": {
-                          "version": "0.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-                          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "har-schema": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-                  "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-                  "dev": true
-                }
-              }
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-              "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
-              "dev": true,
-              "requires": {
-                "boom": "4.x.x",
-                "cryptiles": "3.x.x",
-                "hoek": "4.x.x",
-                "sntp": "2.x.x"
-              },
-              "dependencies": {
-                "boom": {
-                  "version": "4.3.1",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-                  "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-                  "dev": true,
-                  "requires": {
-                    "hoek": "4.x.x"
-                  }
-                },
-                "cryptiles": {
-                  "version": "3.1.2",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-                  "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-                  "dev": true,
-                  "requires": {
-                    "boom": "5.x.x"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "5.2.0",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-                      "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
-                      "dev": true,
-                      "requires": {
-                        "hoek": "4.x.x"
-                      }
-                    }
-                  }
-                },
-                "hoek": {
-                  "version": "4.2.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-                  "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0=",
-                  "dev": true
-                },
-                "sntp": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-                  "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
-                  "dev": true,
-                  "requires": {
-                    "hoek": "4.x.x"
-                  }
-                }
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-              "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-              "dev": true,
-              "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                  "dev": true
-                },
-                "jsprim": {
-                  "version": "1.4.1",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-                  "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-                  "dev": true,
-                  "requires": {
-                    "assert-plus": "1.0.0",
-                    "extsprintf": "1.3.0",
-                    "json-schema": "0.2.3",
-                    "verror": "1.10.0"
-                  },
-                  "dependencies": {
-                    "extsprintf": {
-                      "version": "1.3.0",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-                      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-                      "dev": true
-                    },
-                    "json-schema": {
-                      "version": "0.2.3",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-                      "dev": true
-                    },
-                    "verror": {
-                      "version": "1.10.0",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-                      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-                      "dev": true,
-                      "requires": {
-                        "assert-plus": "^1.0.0",
-                        "core-util-is": "1.0.2",
-                        "extsprintf": "^1.2.0"
-                      },
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.13.1",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-                  "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-                  "dev": true,
-                  "requires": {
-                    "asn1": "~0.2.3",
-                    "assert-plus": "^1.0.0",
-                    "bcrypt-pbkdf": "^1.0.0",
-                    "dashdash": "^1.12.0",
-                    "ecc-jsbn": "~0.1.1",
-                    "getpass": "^0.1.1",
-                    "jsbn": "~0.1.0",
-                    "tweetnacl": "~0.14.0"
-                  },
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-                      "dev": true
-                    },
-                    "bcrypt-pbkdf": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "tweetnacl": "^0.14.3"
-                      }
-                    },
-                    "dashdash": {
-                      "version": "1.14.1",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-                      "dev": true,
-                      "requires": {
-                        "assert-plus": "^1.0.0"
-                      }
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "jsbn": "~0.1.0"
-                      }
-                    },
-                    "getpass": {
-                      "version": "0.1.7",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-                      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-                      "dev": true,
-                      "requires": {
-                        "assert-plus": "^1.0.0"
-                      }
-                    },
-                    "jsbn": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-                      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.5",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-                      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-              "dev": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-              "dev": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-              "dev": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-              "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-              "dev": true,
-              "requires": {
-                "mime-db": "~1.30.0"
-              },
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.30.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-                  "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-                  "dev": true
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-              "dev": true
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-              "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-              "dev": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-              "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg=",
-              "dev": true
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-              "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
-              "dev": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-              "dev": true
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-              "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-              "dev": true,
-              "requires": {
-                "punycode": "^1.4.1"
-              },
-              "dependencies": {
-                "punycode": {
-                  "version": "1.4.1",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                  "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                  "dev": true
-                }
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.0.1"
-              }
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-              "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
-              "dev": true
-            }
+            "hoek": "4.x.x"
           }
         }
       }
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
     "diff": {
-      "version": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "~0.1.0"
+      }
+    },
     "escape-string-regexp": {
-      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "esprima": {
@@ -645,18 +284,50 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
       "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
-    "filesize": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
-      "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g=="
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
     },
-    "formatio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "filesize": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
+      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "samsam": "1.x"
+        "asynckit": "^0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "fs-extra": {
@@ -669,15 +340,128 @@
         "universalify": "^0.1.0"
       }
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "dev": true,
+      "requires": {
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "isarray": {
       "version": "0.0.1",
@@ -685,14 +469,50 @@
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json5": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+      "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -702,21 +522,45 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
     "just-extend": {
       "version": "1.1.27",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
       "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
       "dev": true
     },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
+    },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
     "log-symbols": {
@@ -728,46 +572,433 @@
       }
     },
     "lokijs": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/lokijs/-/lokijs-1.5.1.tgz",
-      "integrity": "sha512-Pj67gdP6CxUPV7AXM/VAnUZNyKR6mx4JxNmZfVG7XeebBZyrd8iLcKxKutc6Z5akJlMb0EeCxPW8/YkCPiMQbw=="
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/lokijs/-/lokijs-1.5.3.tgz",
+      "integrity": "sha1-aVJyL/owSaVaXhwQ7koJR6Pl4Zs="
     },
     "lolex": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
-      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.4.1.tgz",
+      "integrity": "sha512-8QdNQMqlAE2kkc2YWR3Ld0evgE452mmyYZR4HTh54PeH8UAjDipHYh/FHq6y9cAvM68nxGxj5jAz97+WQ2AQEQ==",
       "dev": true
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "requires": {
+        "mime-db": "~1.33.0"
+      }
     },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
-    "mocha": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.6.8",
-        "diff": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.1",
-        "growl": "1.9.2",
-        "he": "1.1.1",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
       },
       "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "mocha": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.1.1.tgz",
+      "integrity": "sha512-kKKs/H1KrMMQIEsWNxGmb4/BGsmj0dkeyotEvbrAuQ01FcWRLssUNXCEUZk6SZtyJBi6EE7SL0zDDtItw1rGhw==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^2.0.0"
+          }
+        }
+      }
+    },
+    "mocha-lcov-reporter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mocha-lcov-reporter/-/mocha-lcov-reporter-1.3.0.tgz",
+      "integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q=",
+      "dev": true
+    },
+    "moment": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
+      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "nise": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.3.tgz",
+      "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^2.0.0",
+        "just-extend": "^1.1.27",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
+      }
+    },
+    "nyc": {
+      "version": "11.7.2",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.7.2.tgz",
+      "integrity": "sha512-gBt7qwsR1vryYfglVjQRx1D+AtMZW5NbUKxb+lZe8SN8KsheGCPGWEsSC9AGQG+r2+te1+10uPHUCahuqm1nGQ==",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^1.0.0",
+        "convert-source-map": "^1.5.1",
+        "debug-log": "^1.0.1",
+        "default-require-extensions": "^1.0.0",
+        "find-cache-dir": "^0.1.1",
+        "find-up": "^2.1.0",
+        "foreground-child": "^1.5.3",
+        "glob": "^7.0.6",
+        "istanbul-lib-coverage": "^1.1.2",
+        "istanbul-lib-hook": "^1.1.0",
+        "istanbul-lib-instrument": "^1.10.0",
+        "istanbul-lib-report": "^1.1.3",
+        "istanbul-lib-source-maps": "^1.2.3",
+        "istanbul-reports": "^1.4.0",
+        "md5-hex": "^1.2.0",
+        "merge-source-map": "^1.1.0",
+        "micromatch": "^3.1.10",
+        "mkdirp": "^0.5.0",
+        "resolve-from": "^2.0.0",
+        "rimraf": "^2.6.2",
+        "signal-exit": "^3.0.1",
+        "spawn-wrap": "^1.4.2",
+        "test-exclude": "^4.2.0",
+        "yargs": "11.1.0",
+        "yargs-parser": "^8.0.0"
+      },
+      "dependencies": {
+        "align-text": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "append-transform": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "^1.0.0"
+          }
+        },
+        "archy": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+          "dev": true
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "dev": true
+        },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+          "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "atob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+          "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.1",
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+          "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+          "dev": true,
+          "requires": {
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.7",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
+        },
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
+        },
+        "base": {
+          "version": "0.11.2",
+          "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+          "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+          "dev": true,
+          "requires": {
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "dev": true
+            }
+          }
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -779,20 +1010,171 @@
             "concat-map": "0.0.1"
           }
         },
-        "browser-stdout": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-          "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-          "dev": true
-        },
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "graceful-readlink": ">= 1.0.0"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
           }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "dev": true
+        },
+        "cache-base": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+          "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+          "dev": true,
+          "requires": {
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
+          }
+        },
+        "caching-transform": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+          "dev": true,
+          "requires": {
+            "md5-hex": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "write-file-atomic": "^1.1.4"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true,
+          "optional": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+          "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+          "dev": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+          "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+          "dev": true,
+          "requires": {
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
+          }
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+          "dev": true
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -800,20 +1182,134 @@
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
+        "convert-source-map": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+          "dev": true
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+          "dev": true
+        },
+        "core-js": {
+          "version": "2.5.6",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+          "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
-        "diff": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+        "debug-log": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
           "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+          "dev": true,
+          "requires": {
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+          "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
+          },
+          "dependencies": {
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "dev": true
+            }
+          }
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+          "dev": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+          "dev": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -821,37 +1317,316 @@
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+              "dev": true,
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "dev": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "dev": true
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+          "dev": true
+        },
+        "foreground-child": {
+          "version": "1.5.6",
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^4",
+            "signal-exit": "^3.0.0"
+          }
+        },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+          "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+          "dev": true,
+          "requires": {
+            "map-cache": "^0.2.2"
+          }
+        },
         "fs.realpath": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "get-value": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+          "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+          "dev": true
+        },
         "glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.2",
+            "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
         },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
           "dev": true
         },
-        "growl": {
-          "version": "1.9.2",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-          "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+          "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+          "dev": true,
+          "requires": {
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "dev": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
         },
         "has-flag": {
           "version": "1.0.0",
@@ -859,10 +1634,48 @@
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
-        "he": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-          "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+        "has-value": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+          "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+          "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+          "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
@@ -881,79 +1694,446 @@
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
-        "json3": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-          "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-          "dev": true
-        },
-        "lodash._baseassign": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-          "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+        "invariant": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+          "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
           "dev": true,
           "requires": {
-            "lodash._basecopy": "^3.0.0",
-            "lodash.keys": "^3.0.0"
+            "loose-envify": "^1.0.0"
           }
         },
-        "lodash._basecopy": {
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "dev": true
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "dev": true,
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+          "dev": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-odd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+          "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+              "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+              "dev": true
+            }
+          }
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+          "dev": true
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "dev": true
+        },
+        "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-          "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
-        "lodash._basecreate": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-          "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+        "istanbul-lib-coverage": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
+          "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
           "dev": true
         },
-        "lodash._getnative": {
-          "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-          "dev": true
-        },
-        "lodash._isiterateecall": {
-          "version": "3.0.9",
-          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-          "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-          "dev": true
-        },
-        "lodash.create": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-          "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+        "istanbul-lib-hook": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
+          "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
           "dev": true,
           "requires": {
-            "lodash._baseassign": "^3.0.0",
-            "lodash._basecreate": "^3.0.0",
-            "lodash._isiterateecall": "^3.0.0"
+            "append-transform": "^0.4.0"
           }
         },
-        "lodash.isarguments": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-          "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-          "dev": true
-        },
-        "lodash.isarray": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-          "dev": true
-        },
-        "lodash.keys": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+        "istanbul-lib-instrument": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
+          "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
           "dev": true,
           "requires": {
-            "lodash._getnative": "^3.0.0",
-            "lodash.isarguments": "^3.0.0",
-            "lodash.isarray": "^3.0.0"
+            "babel-generator": "^6.18.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.18.0",
+            "babel-types": "^6.18.0",
+            "babylon": "^6.18.0",
+            "istanbul-lib-coverage": "^1.2.0",
+            "semver": "^5.3.0"
           }
+        },
+        "istanbul-lib-report": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
+          "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "^1.1.2",
+            "mkdirp": "^0.5.1",
+            "path-parse": "^1.0.5",
+            "supports-color": "^3.1.2"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "dev": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
+          "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+          "dev": true,
+          "requires": {
+            "debug": "^3.1.0",
+            "istanbul-lib-coverage": "^1.1.2",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.6.1",
+            "source-map": "^0.5.3"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-reports": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.4.0.tgz",
+          "integrity": "sha512-OPzVo1fPZ2H+owr8q/LYKLD+vquv9Pj4F+dj808MdHbuQLD7S4ACRjcX+0Tne5Vxt2lxXvdZaL7v+FOOAV281w==",
+          "dev": true,
+          "requires": {
+            "handlebars": "^4.0.3"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+          "dev": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "dev": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+          "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+          "dev": true
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+          "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+          "dev": true,
+          "requires": {
+            "object-visit": "^1.0.0"
+          }
+        },
+        "md5-hex": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "^0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+          "dev": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "merge-source-map": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+          "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+          "dev": true,
+          "requires": {
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "dev": true
+            }
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
@@ -970,6 +2150,27 @@
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
+        "mixin-deep": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+          "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+          "dev": true,
+          "requires": {
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "dev": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
         "mkdirp": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -985,6 +2186,107 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
+        "nanomatch": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+          "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-odd": "^2.0.0",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "dev": true
+            }
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        },
+        "object-copy": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+          "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+          "dev": true,
+          "requires": {
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+          "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.0"
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+          "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
         "once": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -994,1066 +2296,10 @@
             "wrappy": "1"
           }
         },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        }
-      }
-    },
-    "mocha-lcov-reporter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mocha-lcov-reporter/-/mocha-lcov-reporter-1.3.0.tgz",
-      "integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q=",
-      "dev": true
-    },
-    "moment": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
-    },
-    "nise": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
-      "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
-      "dev": true,
-      "requires": {
-        "formatio": "^1.2.0",
-        "just-extend": "^1.1.26",
-        "lolex": "^1.6.0",
-        "path-to-regexp": "^1.7.0",
-        "text-encoding": "^0.6.4"
-      },
-      "dependencies": {
-        "lolex": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-          "dev": true
-        }
-      }
-    },
-    "nyc": {
-      "version": "11.4.1",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
-      "integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
-      "dev": true,
-      "requires": {
-        "archy": "^1.0.0",
-        "arrify": "^1.0.1",
-        "caching-transform": "^1.0.0",
-        "convert-source-map": "^1.3.0",
-        "debug-log": "^1.0.1",
-        "default-require-extensions": "^1.0.0",
-        "find-cache-dir": "^0.1.1",
-        "find-up": "^2.1.0",
-        "foreground-child": "^1.5.3",
-        "glob": "^7.0.6",
-        "istanbul-lib-coverage": "^1.1.1",
-        "istanbul-lib-hook": "^1.1.0",
-        "istanbul-lib-instrument": "^1.9.1",
-        "istanbul-lib-report": "^1.1.2",
-        "istanbul-lib-source-maps": "^1.2.2",
-        "istanbul-reports": "^1.1.3",
-        "md5-hex": "^1.2.0",
-        "merge-source-map": "^1.0.2",
-        "micromatch": "^2.3.11",
-        "mkdirp": "^0.5.0",
-        "resolve-from": "^2.0.0",
-        "rimraf": "^2.5.4",
-        "signal-exit": "^3.0.1",
-        "spawn-wrap": "^1.4.2",
-        "test-exclude": "^4.1.1",
-        "yargs": "^10.0.3",
-        "yargs-parser": "^8.0.0"
-      },
-      "dependencies": {
-        "align-text": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2",
-            "longest": "^1.0.1",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "append-transform": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "default-require-extensions": "^1.0.0"
-          }
-        },
-        "archy": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "arr-flatten": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "async": {
-          "version": "1.5.2",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.3",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.2"
-          }
-        },
-        "babel-generator": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "detect-indent": "^4.0.0",
-            "jsesc": "^1.3.0",
-            "lodash": "^4.17.4",
-            "source-map": "^0.5.6",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "babel-messages": {
-          "version": "6.23.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.22.0"
-          }
-        },
-        "babel-runtime": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "lodash": "^4.17.4"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "debug": "^2.6.8",
-            "globals": "^9.18.0",
-            "invariant": "^2.2.2",
-            "lodash": "^4.17.4"
-          }
-        },
-        "babel-types": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.26.0",
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.4",
-            "to-fast-properties": "^1.0.3"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "bundled": true,
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "braces": {
-          "version": "1.8.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "caching-transform": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "md5-hex": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "write-file-atomic": "^1.1.4"
-          }
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "^0.1.3",
-            "lazy-cache": "^1.0.3"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "commondir": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "convert-source-map": {
-          "version": "1.5.1",
-          "bundled": true,
-          "dev": true
-        },
-        "core-js": {
-          "version": "2.5.3",
-          "bundled": true,
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "4.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "debug-log": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "default-require-extensions": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "detect-indent": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "repeating": "^2.0.0"
-          }
-        },
-        "error-ex": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-arrayish": "^0.2.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "execa": {
-          "version": "0.7.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            }
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "expand-range": {
-          "version": "1.8.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fill-range": "^2.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "filename-regex": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "fill-range": {
-          "version": "2.2.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^1.1.3",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "find-cache-dir": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "commondir": "^1.0.1",
-            "mkdirp": "^0.5.1",
-            "pkg-dir": "^1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "for-in": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "for-own": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "for-in": "^1.0.1"
-          }
-        },
-        "foreground-child": {
-          "version": "1.5.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^4",
-            "signal-exit": "^3.0.0"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "get-caller-file": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "glob-base": {
-          "version": "0.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob-parent": "^2.0.0",
-            "is-glob": "^2.0.0"
-          }
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "bundled": true,
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "handlebars": {
-          "version": "4.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "async": "^1.4.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.4.4",
-            "uglify-js": "^2.6"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.4.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "hosted-git-info": {
-          "version": "2.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-buffer": {
-          "version": "1.1.6",
-          "bundled": true,
-          "dev": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "builtin-modules": "^1.0.0"
-          }
-        },
-        "is-dotfile": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "is-equal-shallow": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-primitive": "^2.0.0"
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-finite": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-posix-bracket": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-primitive": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "istanbul-lib-coverage": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "istanbul-lib-hook": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "append-transform": "^0.4.0"
-          }
-        },
-        "istanbul-lib-instrument": {
-          "version": "1.9.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-generator": "^6.18.0",
-            "babel-template": "^6.16.0",
-            "babel-traverse": "^6.18.0",
-            "babel-types": "^6.18.0",
-            "babylon": "^6.18.0",
-            "istanbul-lib-coverage": "^1.1.1",
-            "semver": "^5.3.0"
-          }
-        },
-        "istanbul-lib-report": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "istanbul-lib-coverage": "^1.1.1",
-            "mkdirp": "^0.5.1",
-            "path-parse": "^1.0.5",
-            "supports-color": "^3.1.2"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "3.2.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "has-flag": "^1.0.0"
-              }
-            }
-          }
-        },
-        "istanbul-lib-source-maps": {
-          "version": "1.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "debug": "^3.1.0",
-            "istanbul-lib-coverage": "^1.1.1",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.6.1",
-            "source-map": "^0.5.3"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
-        "istanbul-reports": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "handlebars": "^4.0.3"
-          }
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "jsesc": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          },
-          "dependencies": {
-            "path-exists": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "bundled": true,
-          "dev": true
-        },
-        "longest": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "md5-hex": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "md5-o-matic": "^0.1.1"
-          }
-        },
-        "md5-o-matic": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "mem": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "merge-source-map": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "source-map": "^0.5.6"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        },
-        "mimic-fn": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object.omit": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "for-own": "^0.1.4",
-            "is-extendable": "^0.1.1"
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
         "optimist": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
             "minimist": "~0.0.1",
@@ -2062,12 +2308,14 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
             "execa": "^0.7.0",
@@ -2077,44 +2325,53 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+          "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
         },
         "p-locate": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
           }
         },
-        "parse-glob": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob-base": "^0.3.0",
-            "is-dotfile": "^1.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.0"
-          }
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
             "error-ex": "^1.2.0"
           }
         },
+        "pascalcase": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+          "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+          "dev": true
+        },
         "path-exists": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
@@ -2122,22 +2379,26 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
           "dev": true
         },
         "path-type": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -2147,17 +2408,20 @@
         },
         "pify": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
             "pinkie": "^2.0.0"
@@ -2165,7 +2429,8 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
             "find-up": "^1.0.0"
@@ -2173,7 +2438,8 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
@@ -2182,56 +2448,22 @@
             }
           }
         },
-        "preserve": {
-          "version": "0.2.0",
-          "bundled": true,
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+          "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
-        },
-        "randomatic": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "kind-of": "^4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "kind-of": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
         },
         "read-pkg": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
             "load-json-file": "^1.0.0",
@@ -2241,7 +2473,8 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
             "find-up": "^1.0.0",
@@ -2250,7 +2483,8 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
@@ -2261,35 +2495,36 @@
         },
         "regenerator-runtime": {
           "version": "0.11.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
           "dev": true
         },
-        "regex-cache": {
-          "version": "0.4.4",
-          "bundled": true,
+        "regex-not": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+          "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
           "dev": true,
           "requires": {
-            "is-equal-shallow": "^0.1.3"
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
           }
-        },
-        "remove-trailing-separator": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
         },
         "repeat-element": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
           "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
           "dev": true
         },
         "repeating": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
             "is-finite": "^1.0.0"
@@ -2297,22 +2532,38 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "dev": true
+        },
+        "resolve-url": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+          "dev": true
+        },
+        "ret": {
+          "version": "0.1.15",
+          "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2321,25 +2572,61 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
             "glob": "^7.0.5"
           }
         },
+        "safe-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+          "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+          "dev": true,
+          "requires": {
+            "ret": "~0.1.10"
+          }
+        },
         "semver": {
-          "version": "5.4.1",
-          "bundled": true,
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
+        },
+        "set-value": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+          "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -2347,27 +2634,153 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
+        },
+        "snapdragon": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+          "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+          "dev": true,
+          "requires": {
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+          "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+          "dev": true,
+          "requires": {
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "dev": true
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+          "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.2.0"
+          }
         },
         "source-map": {
           "version": "0.5.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "source-map-resolve": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+          "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+          "dev": true,
+          "requires": {
+            "atob": "^2.0.0",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+          "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
           "dev": true,
           "requires": {
             "foreground-child": "^1.5.6",
@@ -2379,26 +2792,71 @@
           }
         },
         "spdx-correct": {
-          "version": "1.0.2",
-          "bundled": true,
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "dev": true,
           "requires": {
-            "spdx-license-ids": "^1.0.2"
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
-        "spdx-expression-parse": {
-          "version": "1.0.4",
-          "bundled": true,
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
           "dev": true
         },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
         "spdx-license-ids": {
-          "version": "1.2.2",
-          "bundled": true,
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+          "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
           "dev": true
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+          "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^3.0.0"
+          }
+        },
+        "static-extend": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+          "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+          "dev": true,
+          "requires": {
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -2407,17 +2865,14 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -2427,7 +2882,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -2435,7 +2891,8 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
             "is-utf8": "^0.2.0"
@@ -2443,21 +2900,24 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "test-exclude": {
-          "version": "4.1.1",
-          "bundled": true,
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
+          "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
           "dev": true,
           "requires": {
             "arrify": "^1.0.1",
-            "micromatch": "^2.3.11",
+            "micromatch": "^3.1.8",
             "object-assign": "^4.1.0",
             "read-pkg-up": "^1.0.1",
             "require-main-filename": "^1.0.1"
@@ -2465,17 +2925,51 @@
         },
         "to-fast-properties": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+          "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+          "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+          "dev": true,
+          "requires": {
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
         },
         "trim-right": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
           "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2486,7 +2980,8 @@
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -2500,22 +2995,123 @@
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
           "dev": true,
           "optional": true
         },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "bundled": true,
+        "union-value": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+          "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
           "dev": true,
           "requires": {
-            "spdx-correct": "~1.0.0",
-            "spdx-expression-parse": "~1.0.0"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "set-value": {
+              "version": "0.4.3",
+              "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+              "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+              "dev": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
+              }
+            }
+          }
+        },
+        "unset-value": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+          "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+          "dev": true,
+          "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+              "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+              "dev": true,
+              "requires": {
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                  "dev": true,
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+              "dev": true
+            }
+          }
+        },
+        "urix": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+          "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+          "dev": true
+        },
+        "use": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+          "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+              "dev": true
+            }
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+          "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+          "dev": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
           }
         },
         "which": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -2523,32 +3119,46 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
             "strip-ansi": "^3.0.1"
           },
           "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -2560,12 +3170,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -2575,20 +3187,23 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
-          "version": "10.0.3",
-          "bundled": true,
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
-            "cliui": "^3.2.0",
+            "cliui": "^4.0.0",
             "decamelize": "^1.1.1",
             "find-up": "^2.1.0",
             "get-caller-file": "^1.0.1",
@@ -2599,36 +3214,56 @@
             "string-width": "^2.0.0",
             "which-module": "^2.0.0",
             "y18n": "^3.2.1",
-            "yargs-parser": "^8.0.0"
+            "yargs-parser": "^9.0.2"
           },
           "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "camelcase": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "dev": true
+            },
             "cliui": {
-              "version": "3.2.0",
-              "bundled": true,
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+              "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
               "dev": true,
               "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
                 "wrap-ansi": "^2.0.0"
-              },
-              "dependencies": {
-                "string-width": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
-                  }
-                }
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "yargs-parser": {
+              "version": "9.0.2",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+              "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+              "dev": true,
+              "requires": {
+                "camelcase": "^4.1.0"
               }
             }
           }
         },
         "yargs-parser": {
-          "version": "8.0.0",
-          "bundled": true,
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
@@ -2636,11 +3271,27 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             }
           }
         }
+      }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -2662,10 +3313,21 @@
         "log-symbols": "^2.1.0"
       }
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-to-regexp": {
@@ -2677,10 +3339,58 @@
         "isarray": "0.0.1"
       }
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "progress": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
+    },
+    "request": {
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
+      }
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -2690,6 +3400,12 @@
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "samsam": {
       "version": "1.3.0",
@@ -2703,41 +3419,63 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.2.2.tgz",
-      "integrity": "sha512-BEa593xl+IkIc94nKo0O0LauQC/gQy8Gyv4DkzPwF/9DweC5phr1y+42zibCpn9abfkdHxt9r8AhD0R6u9DE/Q==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
+      "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
       "dev": true,
       "requires": {
+        "@sinonjs/formatio": "^2.0.0",
         "diff": "^3.1.0",
-        "formatio": "1.2.0",
         "lodash.get": "^4.4.2",
         "lolex": "^2.2.0",
         "nise": "^1.2.0",
         "supports-color": "^5.1.0",
         "type-detect": "^4.0.5"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^2.0.0"
-          }
-        }
+      }
+    },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "dev": true,
+      "requires": {
+        "hoek": "4.x.x"
       }
     },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "sshpk": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
     },
     "text-encoding": {
       "version": "0.6.4",
@@ -2764,10 +3502,35 @@
         "tmp": "0.0.33"
       }
     },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "dev": true,
+      "requires": {
+        "punycode": "^1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
     "type-detect": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.7.tgz",
-      "integrity": "sha512-4Rh17pAMVdMWzktddFhISRnUnFIStObtUMNGzDwlA6w/77bmGv3aBbRdCmQR6IjzfkTo9otnW+2K/cDRhKSxDA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "universalify": {
@@ -2776,9 +3539,26 @@
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/Unity-Technologies/unity-cache-server#readme",
   "devDependencies": {
     "coveralls": "^3.0.0",
-    "mocha": "^3.5.3",
+    "mocha": "^5.1.1",
     "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^11.4.1",
     "sinon": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unity-cache-server",
-  "version": "6.0.2",
+  "version": "6.1.0-preview.0",
   "description": "Unity Cache Server",
   "main": "lib/index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "unity-cache-server-import": "./import.js"
   },
   "scripts": {
-    "test": "nyc mocha",
-    "coverage": "nyc npm test && nyc report --reporter=lcov; open coverage/lcov-report/index.html",
+    "test": "export NODE_ENV=test;nyc mocha",
+    "coverage": "export NODE_ENV=test;nyc npm test && nyc report --reporter=lcov; open coverage/lcov-report/index.html",
     "start": "node main.js",
-    "coveralls": "nyc report --reporter=lcovonly && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
+    "coveralls": "export NODE_ENV=test;nyc report --reporter=lcovonly && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "repository": {
     "type": "git",

--- a/test/cache_api.js
+++ b/test/cache_api.js
@@ -1,11 +1,13 @@
 const assert = require('assert');
-const tmp = require('tmp');
+const tmp = require('tmp-promise');
 const loki = require('lokijs');
 const fs = require('fs-extra');
 const sleep = require('./test_utils').sleep;
 const generateCommandData = require('./test_utils').generateCommandData;
 const readStream = require('./test_utils').readStream;
-const EventEmitter = require('events');
+const sinon = require('sinon');
+const crypto = require('crypto');
+const consts = require('../lib/constants');
 
 const test_modules = [
     {
@@ -17,14 +19,16 @@ const test_modules = [
             minFreeBlockSize: 1024,
             persistenceOptions: {
                 adapter: new loki.LokiMemoryAdapter()
-            }
+            },
+            highReliability: false
         }
     },
     {
         name: "cache_fs",
         path: "../lib/cache/cache_fs",
         options: {
-            cachePath: tmp.tmpNameSync({})
+            cachePath: tmp.tmpNameSync({}),
+            highReliability: false
         }
     }
 ];
@@ -58,13 +62,6 @@ describe("Cache API", () => {
                 });
             });
 
-            describe("registerClusterWorker", () => {
-                it("should return with no error", done => {
-                    cache.registerClusterWorker(new EventEmitter());
-                    done();
-                });
-            });
-
             describe("shutdown", () => {
                 it("should return with no error", () => {
                     return cache.shutdown();
@@ -88,75 +85,61 @@ describe("Cache API", () => {
             });
 
             describe("endPutTransaction & getFileInfo", () => {
-                let fileData, trx;
-
-                beforeEach(() => {
-                    fileData = generateCommandData(1024, 1024);
-                    return cache.createPutTransaction(fileData.guid, fileData.hash)
-                        .then(result => { trx = result; });
-                });
-
-                it("should call finalize on the transaction", () => {
-                    let called = false;
-                    trx.finalize = () => {
-                        called = true;
-                        return Promise.resolve();
+                it("should call finalize() on the given transaction", async () => {
+                    const transaction = {
+                        finalize: () => {},
+                        guid: Buffer.alloc(consts.GUID_SIZE, 0),
+                        hash: Buffer.alloc(consts.HASH_SIZE, 0),
+                        files: []
                     };
 
-                    cache.endPutTransaction(trx).then(() => assert(called));
+                    const mock = sinon.mock(transaction);
+                    mock.expects("finalize").once();
+
+                    await cache.endPutTransaction(transaction);
+                    mock.verify();
                 });
 
-                it("should add info, asset, and resource files to the cache that were written to the transaction", () => {
-                    return trx.getWriteStream('i', fileData.info.length)
-                        .then(stream => stream.end(fileData.info))
-                        .then(() => cache.endPutTransaction(trx))
-                        .then(() => sleep(50))
-                        .then(() => cache.getFileInfo('i', fileData.guid, fileData.hash))
+                it("should add info, asset, and resource files to the cache that were written to the transaction", async () => {
+                    const fileData = generateCommandData(1024, 1024);
+                    const trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
+                    await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                    await trx.getWriteStream('a', fileData.info.length).then(s => s.end(fileData.bin));
+                    await trx.getWriteStream('r', fileData.info.length).then(s => s.end(fileData.resource));
+                    await cache.endPutTransaction(trx);
+                    await sleep(50);
+
+                    await cache.getFileInfo('i', fileData.guid, fileData.hash)
                         .then(info => assert.equal(info.size, fileData.info.length));
+
+                    await cache.getFileInfo('a', fileData.guid, fileData.hash)
+                        .then(info => assert.equal(info.size, fileData.bin.length));
+
+                    await cache.getFileInfo('r', fileData.guid, fileData.hash)
+                        .then(info => assert.equal(info.size, fileData.resource.length));
+
                 });
 
-                it("should return an error if any files were partially written to the transaction", () => {
-                    return trx.getWriteStream('i', fileData.info.length)
-                        .then(stream => stream.end(fileData.info.slice(0, 1)))
-                        .then(() => cache.endPutTransaction(trx))
+                it("should return an error if any files were partially written to the transaction", async () => {
+                    const fileData = generateCommandData(1024, 1024);
+                    const trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
+                    const stream = await trx.getWriteStream('i', fileData.info.length);
+                    await stream.end(fileData.info.slice(0, 1));
+                    return cache.endPutTransaction(trx)
                         .then(() => { throw new Error("Expected error!"); }, err =>  assert(err));
                 });
 
-                it("should not add files to the cache that were partially written to the transaction", () => {
-                    return trx.getWriteStream('i', fileData.info.length)
-                        .then(stream => stream.end(fileData.info.slice(0, 1)))
-                        .then(() => cache.endPutTransaction(trx))
-                        .then(() => {}, err => assert(err))
-                        .then(() => cache.getFileInfo('i', fileData.guid, fileData.hash))
+                it("should not add files to the cache that were partially written to the transaction", async () => {
+                    const fileData = generateCommandData(1024, 1024);
+                    const trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
+                    const stream = await trx.getWriteStream('i', fileData.info.length);
+                    await stream.end(fileData.info.slice(0, 1));
+                    await cache.endPutTransaction(trx)
+                        .then(() => {}, err => assert(err));
+
+                    return cache.getFileInfo('i', fileData.guid, fileData.hash)
                         .then(() => { throw new Error("Expected error!"); }, err =>  assert(err));
                 });
-            });
-
-            describe("getFileStream", function() {
-
-                let fileData;
-
-                beforeEach(() => {
-                    fileData = generateCommandData(1024, 1024);
-                    let trx;
-                    return cache.createPutTransaction(fileData.guid, fileData.hash)
-                        .then(result => { trx = result; })
-                        .then(() => trx.getWriteStream('i', fileData.info.length))
-                        .then(stream => stream.end(fileData.info))
-                        .then(() => cache.endPutTransaction(trx))
-                        .then(() => sleep(50));
-                });
-
-                it("should return a readable stream for a file that exists in the cache", () => {
-                    return cache.getFileStream('i', fileData.guid, fileData.hash)
-                        .then(stream => assert(stream instanceof require('stream').Readable));
-                });
-
-                it("should return an error for a file that does not exist in the cache", () => {
-                    return cache.getFileStream('a', fileData.guid, fileData.hash)
-                        .then(() => { throw new Error("Expected error!"); }, err =>  assert(err));
-                });
-
 
                 it("should handle files being replaced while read streams to the same file are already open", async () => {
                     const TEST_FILE_SIZE = 1024 * 64 * 2;
@@ -198,14 +181,157 @@ describe("Cache API", () => {
                     buf = await readStream(rStream, fData.resource.length);
                     assert.equal(buf.compare(fData.resource), 0);
                 });
+
+                describe("High Reliability Mode", () => {
+                    before(async () => {
+                        const opts = cache._options;
+                        opts.highReliability = true;
+                        opts.highReliabilityOptions = {
+                            reliabilityThreshold: 1
+                        };
+
+                        await cache.init(opts);
+                    });
+
+                    after(async () => {
+                        const opts = cache._options;
+                        opts.highReliability = false;
+                        await cache.init(opts);
+                    });
+
+                    it("should not add a version to the cache until the reliabilityFactor meets the reliabilityThreshold", async () => {
+                        const fileData = generateCommandData(1024, 1024);
+                        let t = await cache.createPutTransaction(fileData.guid, fileData.hash);
+                        await t.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                        await t.getWriteStream('a', fileData.bin.length).then(s => s.end(fileData.bin));
+                        await cache.endPutTransaction(t);
+                        await sleep(50);
+                        await cache.getFileInfo('i', fileData.guid, fileData.hash)
+                            .then(() => { throw new Error("Expected error!"); }, err => assert(err));
+                        await cache.getFileInfo('a', fileData.guid, fileData.hash)
+                            .then(() => { throw new Error("Expected error!"); }, err => assert(err));
+
+                        t = await cache.createPutTransaction(fileData.guid, fileData.hash);
+                        await t.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                        await t.getWriteStream('a', fileData.bin.length).then(s => s.end(fileData.bin));
+                        await cache.endPutTransaction(t);
+                        await sleep(50);
+                        await cache.getFileInfo('i', fileData.guid, fileData.hash)
+                            .then(i => assert.equal(i.size, fileData.info.length));
+                        await cache.getFileInfo('a', fileData.guid, fileData.hash)
+                            .then(i => assert.equal(i.size, fileData.bin.length));
+                    });
+
+                    it("should not add a version to the cache if all transactions for a version do not contain the same number of files", async () => {
+                        const fileData = generateCommandData(1024, 1024);
+                        let t = await cache.createPutTransaction(fileData.guid, fileData.hash);
+                        await t.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                        await t.getWriteStream('a', fileData.bin.length).then(s => s.end(fileData.bin));
+                        await cache.endPutTransaction(t);
+                        await sleep(50);
+                        await cache.getFileInfo('i', fileData.guid, fileData.hash)
+                            .then(() => { throw new Error("Expected error!"); }, err => assert(err));
+
+                        await cache.getFileInfo('a', fileData.guid, fileData.hash)
+                            .then(() => { throw new Error("Expected error!"); }, err => assert(err));
+
+                        // This time we just add the info file, so the version should be deemed unreliable
+                        t = await cache.createPutTransaction(fileData.guid, fileData.hash);
+                        await t.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                        await cache.endPutTransaction(t);
+                        await sleep(50);
+
+                        await cache.getFileInfo('i', fileData.guid, fileData.hash)
+                            .then(() => { throw new Error("Expected error!"); }, err => assert(err));
+                        await cache.getFileInfo('a', fileData.guid, fileData.hash)
+                            .then(() => { throw new Error("Expected error!"); }, err => assert(err));
+                    });
+
+
+                    it("should not allow new files to be written to an existing version", async () => {
+                        // Commit a version
+                        const fileData = generateCommandData(1024, 1024);
+                        for(let i = 0; i < cache._options.highReliabilityOptions.reliabilityThreshold + 1; i++) {
+                            const trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
+                            await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                            await trx.getWriteStream('a', fileData.info.length).then(s => s.end(fileData.bin));
+                            await trx.getWriteStream('r', fileData.info.length).then(s => s.end(fileData.resource));
+                            await cache.endPutTransaction(trx);
+                            await sleep(50);
+                        }
+
+                        // Try to change it with new data
+                        const newData = Buffer.from(crypto.randomBytes(fileData.info.length * 2).toString('ascii'), 'ascii');
+
+                        const trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
+                        const stream = await trx.getWriteStream('i', newData.length);
+                        await stream.end(newData);
+                        await cache.endPutTransaction(trx);
+                        await sleep(50);
+                        const info = await cache.getFileInfo('i', fileData.guid, fileData.hash);
+                        assert.equal(info.size, fileData.info.length);
+                    });
+
+                    it("should not allow a previously unstable version to become stable", async () => {
+                        const fileData = generateCommandData(1024, 1024);
+                        let trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
+                        await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                        await cache.endPutTransaction(trx);
+                        await sleep(50);
+
+                        // Next version will use the wrong data, making it unreliable
+                        trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
+                        await trx.getWriteStream('i', fileData.resource.length).then(s => s.end(fileData.resource));
+                        await cache.endPutTransaction(trx);
+                        await sleep(50);
+
+                        // Verify it doesn't exist
+                        await cache.getFileInfo('i', fileData.guid, fileData.hash)
+                            .then(() => { throw new Error("Expected error!"); }, err => assert(err));
+
+                        // Try to add the correct data more than the reliability threshold .. should still not be found
+                        for(let i = 0; i < cache._options.highReliabilityOptions.reliabilityThreshold + 1; i++) {
+                            trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
+                            await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                            await cache.endPutTransaction(trx);
+                            await sleep(50);
+
+                            await cache.getFileInfo('i', fileData.guid, fileData.hash)
+                                .then(() => { throw new Error("Expected error!"); }, err => assert(err));
+                        }
+                    });
+                });
+            });
+
+            describe("getFileStream", function() {
+
+                let fileData;
+
+                beforeEach(async () => {
+                    fileData = generateCommandData(1024, 1024);
+                    const trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
+                    await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                    await cache.endPutTransaction(trx);
+                    await sleep(50);
+                });
+
+                it("should return a readable stream for a file that exists in the cache", () => {
+                    return cache.getFileStream('i', fileData.guid, fileData.hash)
+                        .then(stream => assert(stream instanceof require('stream').Readable));
+                });
+
+                it("should return an error for a file that does not exist in the cache", () => {
+                    return cache.getFileStream('a', fileData.guid, fileData.hash)
+                        .then(() => { throw new Error("Expected error!"); }, err =>  assert(err));
+                });
             });
         });
     });
 });
 
-describe("PutTransaction API", function() {
-    test_modules.forEach(function (module) {
-        describe(module.name, function () {
+describe("PutTransaction API", () => {
+    test_modules.forEach((module) => {
+        describe(module.name, () => {
             let cache, fileData, trx;
 
             before(() => {
@@ -219,64 +345,54 @@ describe("PutTransaction API", function() {
                 return fs.remove(module.options.cachePath);
             });
 
-            beforeEach(() => {
-                return cache.createPutTransaction(fileData.guid, fileData.hash)
-                    .then(result => { trx = result; });
+            beforeEach( async () => {
+                trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
             });
 
-            describe("get guid", function() {
+            describe("get guid", () => {
                 it("should return the file guid for the transaction", () => {
                     assert.strictEqual(trx.guid, fileData.guid);
                 });
             });
 
-            describe("get hash", function() {
+            describe("get hash", () => {
                 it("should return the file hash for the transaction", () => {
                     assert.strictEqual(trx.hash, fileData.hash);
                 });
             });
 
-            describe("get manifest", function() {
-                it("should return an array of file types that were successfully written to the transaction", () => {
-                    return trx.getWriteStream('i', fileData.info.length)
-                        .then(stream => stream.end(fileData.info))
-                        .then(() => trx.getWriteStream('r', fileData.resource.length))
-                        .then(stream => stream.end(fileData.resource))
-                        .then(() => trx.getWriteStream('a', fileData.bin.length))
-                        .then(stream => stream.end(fileData.bin))
-                        .then(() => trx.finalize())
-                        .then(() => {
-                            const m = trx.manifest;
-                            ['i', 'a', 'r'].forEach((t) => assert(m.indexOf(t) >= 0));
-                        });
+            describe("get manifest", () => {
+                it("should return an array of file types that were successfully written to the transaction", async () => {
+                    await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                    await trx.getWriteStream('r', fileData.resource.length).then(s => s.end(fileData.resource));
+                    await trx.getWriteStream('a', fileData.bin.length).then(s => s.end(fileData.bin));
+                    await trx.finalize();
+                    const m = trx.manifest;
+                    ['i', 'a', 'r'].forEach((t) => assert(m.indexOf(t) >= 0));
                 });
             });
 
-            describe("get files", function() {
+            describe("get files", () => {
                 it("should return an empty array before finalize() is called", () => {
                     assert.strictEqual(trx.files.length, 0);
                 });
 
-                it("should return a list of objects that represent completed files for the transaction", () => {
-                    return trx.getWriteStream('i', fileData.info.length)
-                        .then(stream => stream.end(fileData.info))
-                        .then(() => trx.finalize())
-                        .then(() => assert.equal(trx.files.length, 1));
+                it("should return a list of objects that represent completed files for the transaction", async () => {
+                    await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                    await trx.finalize();
+                    assert.equal(trx.files.length, 1);
                 });
             });
 
             describe("finalize", function() {
-                it("should return an error if any file was not fully written", () => {
-                    return trx.getWriteStream('i', fileData.info.length)
-                        .then(stream => stream.end(fileData.info.slice(0, 1)))
-                        .then(() => trx.finalize())
-                        .then(() => { throw new Error("Expected error!"); }, err =>  assert(err));
+                it("should return an error if any file was not fully written", async () => {
+                    await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info.slice(0, 1)));
+                    await trx.finalize().then(() => { throw new Error("Expected error!"); }, err => assert(err));
                 });
 
-                it("should return with no error and no value if the transaction was successfully finalized", () => {
-                    return trx.getWriteStream('i', fileData.info.length)
-                        .then(stream => stream.end(fileData.info))
-                        .then(() => trx.finalize())
+                it("should return with no error and no value if the transaction was successfully finalized", async () => {
+                    await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                    await trx.finalize();
                 });
 
                 it("should emit a 'finalize' event", (done) => {
@@ -291,11 +407,11 @@ describe("PutTransaction API", function() {
                         .then(stream => assert(stream instanceof require('stream').Writable));
                 });
 
-                it("should only accept types of 'i', 'a', or 'r", () => {
-                    return trx.getWriteStream('i', 1)
-                        .then(() => trx.getWriteStream('a', 1))
-                        .then(() => trx.getWriteStream('r', 1))
-                        .then(() => trx.getWriteStream('x', 1))
+                it("should only accept types of 'i', 'a', or 'r", async () => {
+                    await trx.getWriteStream('i', 1);
+                    await trx.getWriteStream('a', 1);
+                    await trx.getWriteStream('r', 1);
+                    await trx.getWriteStream('x', 1)
                         .then(() => { throw new Error("Expected error!"); }, err => assert(err));
                 });
 
@@ -307,6 +423,35 @@ describe("PutTransaction API", function() {
                 it("should return an error for size less than 0", () => {
                     return trx.getWriteStream('i', -1)
                         .then(() => { throw new Error("Expected error!"); }, err => assert(err))
+                });
+            });
+
+            describe("invalidate", () => {
+                it("should cause isValid to return false", async () => {
+                    assert.ok(trx.isValid);
+                    await trx.invalidate();
+                    assert.ok(!trx.isValid);
+                });
+
+                it("should cause files to return an empty array", async () => {
+                    await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                    await trx.finalize();
+                    assert.equal(trx.files.length, 1);
+                    await trx.invalidate();
+                    assert.equal(trx.files.length, 0);
+                });
+            });
+
+            describe("writeFilesToPath", () => {
+                it("should copy or write file data to the specified path", async () => {
+                    await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                    await trx.finalize();
+                    const o = await tmp.dir({ unsafeCleanup: true });
+                    const files = await trx.writeFilesToPath(o.path);
+                    assert.ok(files);
+                    assert.equal(files.length, 1);
+                    await fs.access(files[0]);
+                    o.cleanup();
                 });
             });
         });

--- a/test/cache_api.js
+++ b/test/cache_api.js
@@ -399,6 +399,20 @@ describe("PutTransaction API", () => {
                     trx.once('finalize', () => done());
                     trx.finalize();
                 });
+
+                it("should call validateHash", async () => {
+                    const spy = sinon.spy(trx, "validateHash");
+                    await trx.finalize();
+                    assert(spy.called);
+                });
+            });
+
+            describe("validateHash", function () {
+                it("should invalidate the transaction if the hash is empty (0 values)", async () => {
+                    const myTrx = await cache.createPutTransaction(fileData.guid, Buffer.alloc(consts.HASH_SIZE, 0));
+                    await myTrx.validateHash();
+                    assert(!myTrx.isValid);
+                });
             });
 
             describe("getWriteStream", function() {

--- a/test/cache_api.js
+++ b/test/cache_api.js
@@ -187,7 +187,7 @@ describe("Cache API", () => {
                         const opts = cache._options;
                         opts.highReliability = true;
                         opts.highReliabilityOptions = {
-                            reliabilityThreshold: 1
+                            reliabilityThreshold: 2
                         };
 
                         await cache.init(opts);

--- a/test/cache_api.js
+++ b/test/cache_api.js
@@ -103,19 +103,19 @@ describe("Cache API", () => {
                 it("should add info, asset, and resource files to the cache that were written to the transaction", async () => {
                     const fileData = generateCommandData(1024, 1024);
                     const trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
-                    await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
-                    await trx.getWriteStream('a', fileData.info.length).then(s => s.end(fileData.bin));
-                    await trx.getWriteStream('r', fileData.info.length).then(s => s.end(fileData.resource));
+                    await trx.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length).then(s => s.end(fileData.info));
+                    await trx.getWriteStream(consts.FILE_TYPE.BIN, fileData.info.length).then(s => s.end(fileData.bin));
+                    await trx.getWriteStream(consts.FILE_TYPE.RESOURCE, fileData.info.length).then(s => s.end(fileData.resource));
                     await cache.endPutTransaction(trx);
                     await sleep(50);
 
-                    await cache.getFileInfo('i', fileData.guid, fileData.hash)
+                    await cache.getFileInfo(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash)
                         .then(info => assert.equal(info.size, fileData.info.length));
 
-                    await cache.getFileInfo('a', fileData.guid, fileData.hash)
+                    await cache.getFileInfo(consts.FILE_TYPE.BIN, fileData.guid, fileData.hash)
                         .then(info => assert.equal(info.size, fileData.bin.length));
 
-                    await cache.getFileInfo('r', fileData.guid, fileData.hash)
+                    await cache.getFileInfo(consts.FILE_TYPE.RESOURCE, fileData.guid, fileData.hash)
                         .then(info => assert.equal(info.size, fileData.resource.length));
 
                 });
@@ -123,7 +123,7 @@ describe("Cache API", () => {
                 it("should return an error if any files were partially written to the transaction", async () => {
                     const fileData = generateCommandData(1024, 1024);
                     const trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
-                    const stream = await trx.getWriteStream('i', fileData.info.length);
+                    const stream = await trx.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length);
                     await stream.end(fileData.info.slice(0, 1));
                     return cache.endPutTransaction(trx)
                         .then(() => { throw new Error("Expected error!"); }, err =>  assert(err));
@@ -132,30 +132,29 @@ describe("Cache API", () => {
                 it("should not add files to the cache that were partially written to the transaction", async () => {
                     const fileData = generateCommandData(1024, 1024);
                     const trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
-                    const stream = await trx.getWriteStream('i', fileData.info.length);
+                    const stream = await trx.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length);
                     await stream.end(fileData.info.slice(0, 1));
                     await cache.endPutTransaction(trx)
                         .then(() => {}, err => assert(err));
 
-                    return cache.getFileInfo('i', fileData.guid, fileData.hash)
+                    return cache.getFileInfo(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash)
                         .then(() => { throw new Error("Expected error!"); }, err =>  assert(err));
                 });
 
                 it("should handle files being replaced while read streams to the same file are already open", async () => {
                     const TEST_FILE_SIZE = 1024 * 64 * 2;
-                    const FILE_TYPE = 'i';
 
                     const fData = generateCommandData(TEST_FILE_SIZE, TEST_FILE_SIZE);
 
                     // Add a file to the cache (use the info data)
                     let trx = await cache.createPutTransaction(fData.guid, fData.hash);
-                    let wStream = await trx.getWriteStream('i', fData.info.length);
+                    let wStream = await trx.getWriteStream(consts.FILE_TYPE.INFO, fData.info.length);
                     await new Promise(resolve => wStream.end(fData.info, resolve));
                     await cache.endPutTransaction(trx);
                     await sleep(50);
 
                     // Get a read stream
-                    let rStream = await cache.getFileStream(FILE_TYPE, fData.guid, fData.hash);
+                    let rStream = await cache.getFileStream(consts.FILE_TYPE.INFO, fData.guid, fData.hash);
 
                     // Read a block
                     let buf = Buffer.allocUnsafe(fData.info.length);
@@ -164,7 +163,7 @@ describe("Cache API", () => {
 
                     // Replace the file (use the resource data)
                     trx = await cache.createPutTransaction(fData.guid, fData.hash);
-                    wStream = await trx.getWriteStream(FILE_TYPE, fData.resource.length);
+                    wStream = await trx.getWriteStream(consts.FILE_TYPE.INFO, fData.resource.length);
                     await new Promise(resolve => wStream.end(fData.resource, resolve));
                     await cache.endPutTransaction(trx);
                     await sleep(50);
@@ -175,7 +174,7 @@ describe("Cache API", () => {
                     assert.equal(buf.compare(fData.info), 0);
 
                     // Get another new read stream to the same guid
-                    rStream = await cache.getFileStream(FILE_TYPE, fData.guid, fData.hash);
+                    rStream = await cache.getFileStream(consts.FILE_TYPE.INFO, fData.guid, fData.hash);
 
                     // Read the file and compare it to the resource data
                     buf = await readStream(rStream, fData.resource.length);
@@ -202,48 +201,48 @@ describe("Cache API", () => {
                     it("should not add a version to the cache until the reliabilityFactor meets the reliabilityThreshold", async () => {
                         const fileData = generateCommandData(1024, 1024);
                         let t = await cache.createPutTransaction(fileData.guid, fileData.hash);
-                        await t.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
-                        await t.getWriteStream('a', fileData.bin.length).then(s => s.end(fileData.bin));
+                        await t.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length).then(s => s.end(fileData.info));
+                        await t.getWriteStream(consts.FILE_TYPE.BIN, fileData.bin.length).then(s => s.end(fileData.bin));
                         await cache.endPutTransaction(t);
                         await sleep(50);
-                        await cache.getFileInfo('i', fileData.guid, fileData.hash)
+                        await cache.getFileInfo(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash)
                             .then(() => { throw new Error("Expected error!"); }, err => assert(err));
-                        await cache.getFileInfo('a', fileData.guid, fileData.hash)
+                        await cache.getFileInfo(consts.FILE_TYPE.BIN, fileData.guid, fileData.hash)
                             .then(() => { throw new Error("Expected error!"); }, err => assert(err));
 
                         t = await cache.createPutTransaction(fileData.guid, fileData.hash);
-                        await t.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
-                        await t.getWriteStream('a', fileData.bin.length).then(s => s.end(fileData.bin));
+                        await t.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length).then(s => s.end(fileData.info));
+                        await t.getWriteStream(consts.FILE_TYPE.BIN, fileData.bin.length).then(s => s.end(fileData.bin));
                         await cache.endPutTransaction(t);
                         await sleep(50);
-                        await cache.getFileInfo('i', fileData.guid, fileData.hash)
+                        await cache.getFileInfo(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash)
                             .then(i => assert.equal(i.size, fileData.info.length));
-                        await cache.getFileInfo('a', fileData.guid, fileData.hash)
+                        await cache.getFileInfo(consts.FILE_TYPE.BIN, fileData.guid, fileData.hash)
                             .then(i => assert.equal(i.size, fileData.bin.length));
                     });
 
                     it("should not add a version to the cache if all transactions for a version do not contain the same number of files", async () => {
                         const fileData = generateCommandData(1024, 1024);
                         let t = await cache.createPutTransaction(fileData.guid, fileData.hash);
-                        await t.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
-                        await t.getWriteStream('a', fileData.bin.length).then(s => s.end(fileData.bin));
+                        await t.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length).then(s => s.end(fileData.info));
+                        await t.getWriteStream(consts.FILE_TYPE.BIN, fileData.bin.length).then(s => s.end(fileData.bin));
                         await cache.endPutTransaction(t);
                         await sleep(50);
-                        await cache.getFileInfo('i', fileData.guid, fileData.hash)
+                        await cache.getFileInfo(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash)
                             .then(() => { throw new Error("Expected error!"); }, err => assert(err));
 
-                        await cache.getFileInfo('a', fileData.guid, fileData.hash)
+                        await cache.getFileInfo(consts.FILE_TYPE.BIN, fileData.guid, fileData.hash)
                             .then(() => { throw new Error("Expected error!"); }, err => assert(err));
 
                         // This time we just add the info file, so the version should be deemed unreliable
                         t = await cache.createPutTransaction(fileData.guid, fileData.hash);
-                        await t.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                        await t.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length).then(s => s.end(fileData.info));
                         await cache.endPutTransaction(t);
                         await sleep(50);
 
-                        await cache.getFileInfo('i', fileData.guid, fileData.hash)
+                        await cache.getFileInfo(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash)
                             .then(() => { throw new Error("Expected error!"); }, err => assert(err));
-                        await cache.getFileInfo('a', fileData.guid, fileData.hash)
+                        await cache.getFileInfo(consts.FILE_TYPE.BIN, fileData.guid, fileData.hash)
                             .then(() => { throw new Error("Expected error!"); }, err => assert(err));
                     });
 
@@ -253,9 +252,9 @@ describe("Cache API", () => {
                         const fileData = generateCommandData(1024, 1024);
                         for(let i = 0; i < cache._options.highReliabilityOptions.reliabilityThreshold + 1; i++) {
                             const trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
-                            await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
-                            await trx.getWriteStream('a', fileData.info.length).then(s => s.end(fileData.bin));
-                            await trx.getWriteStream('r', fileData.info.length).then(s => s.end(fileData.resource));
+                            await trx.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length).then(s => s.end(fileData.info));
+                            await trx.getWriteStream(consts.FILE_TYPE.BIN, fileData.info.length).then(s => s.end(fileData.bin));
+                            await trx.getWriteStream(consts.FILE_TYPE.RESOURCE, fileData.info.length).then(s => s.end(fileData.resource));
                             await cache.endPutTransaction(trx);
                             await sleep(50);
                         }
@@ -264,39 +263,39 @@ describe("Cache API", () => {
                         const newData = Buffer.from(crypto.randomBytes(fileData.info.length * 2).toString('ascii'), 'ascii');
 
                         const trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
-                        const stream = await trx.getWriteStream('i', newData.length);
+                        const stream = await trx.getWriteStream(consts.FILE_TYPE.INFO, newData.length);
                         await stream.end(newData);
                         await cache.endPutTransaction(trx);
                         await sleep(50);
-                        const info = await cache.getFileInfo('i', fileData.guid, fileData.hash);
+                        const info = await cache.getFileInfo(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash);
                         assert.equal(info.size, fileData.info.length);
                     });
 
                     it("should not allow a previously unstable version to become stable", async () => {
                         const fileData = generateCommandData(1024, 1024);
                         let trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
-                        await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                        await trx.getWriteStream(consts.FILE_TYPE.BIN, fileData.info.length).then(s => s.end(fileData.info));
                         await cache.endPutTransaction(trx);
                         await sleep(50);
 
                         // Next version will use the wrong data, making it unreliable
                         trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
-                        await trx.getWriteStream('i', fileData.resource.length).then(s => s.end(fileData.resource));
+                        await trx.getWriteStream(consts.FILE_TYPE.BIN, fileData.resource.length).then(s => s.end(fileData.resource));
                         await cache.endPutTransaction(trx);
                         await sleep(50);
 
                         // Verify it doesn't exist
-                        await cache.getFileInfo('i', fileData.guid, fileData.hash)
+                        await cache.getFileInfo(consts.FILE_TYPE.BIN, fileData.guid, fileData.hash)
                             .then(() => { throw new Error("Expected error!"); }, err => assert(err));
 
                         // Try to add the correct data more than the reliability threshold .. should still not be found
                         for(let i = 0; i < cache._options.highReliabilityOptions.reliabilityThreshold + 1; i++) {
                             trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
-                            await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                            await trx.getWriteStream(consts.FILE_TYPE.BIN, fileData.info.length).then(s => s.end(fileData.info));
                             await cache.endPutTransaction(trx);
                             await sleep(50);
 
-                            await cache.getFileInfo('i', fileData.guid, fileData.hash)
+                            await cache.getFileInfo(consts.FILE_TYPE.BIN, fileData.guid, fileData.hash)
                                 .then(() => { throw new Error("Expected error!"); }, err => assert(err));
                         }
                     });
@@ -310,18 +309,18 @@ describe("Cache API", () => {
                 beforeEach(async () => {
                     fileData = generateCommandData(1024, 1024);
                     const trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
-                    await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                    await trx.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length).then(s => s.end(fileData.info));
                     await cache.endPutTransaction(trx);
                     await sleep(50);
                 });
 
                 it("should return a readable stream for a file that exists in the cache", () => {
-                    return cache.getFileStream('i', fileData.guid, fileData.hash)
+                    return cache.getFileStream(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash)
                         .then(stream => assert(stream instanceof require('stream').Readable));
                 });
 
                 it("should return an error for a file that does not exist in the cache", () => {
-                    return cache.getFileStream('a', fileData.guid, fileData.hash)
+                    return cache.getFileStream(consts.FILE_TYPE.BIN, fileData.guid, fileData.hash)
                         .then(() => { throw new Error("Expected error!"); }, err =>  assert(err));
                 });
             });
@@ -363,12 +362,12 @@ describe("PutTransaction API", () => {
 
             describe("get manifest", () => {
                 it("should return an array of file types that were successfully written to the transaction", async () => {
-                    await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
-                    await trx.getWriteStream('r', fileData.resource.length).then(s => s.end(fileData.resource));
-                    await trx.getWriteStream('a', fileData.bin.length).then(s => s.end(fileData.bin));
+                    await trx.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length).then(s => s.end(fileData.info));
+                    await trx.getWriteStream(consts.FILE_TYPE.RESOURCE, fileData.resource.length).then(s => s.end(fileData.resource));
+                    await trx.getWriteStream(consts.FILE_TYPE.BIN, fileData.bin.length).then(s => s.end(fileData.bin));
                     await trx.finalize();
                     const m = trx.manifest;
-                    ['i', 'a', 'r'].forEach((t) => assert(m.indexOf(t) >= 0));
+                    [consts.FILE_TYPE.INFO, consts.FILE_TYPE.BIN, consts.FILE_TYPE.RESOURCE].forEach((t) => assert(m.indexOf(t) >= 0));
                 });
             });
 
@@ -378,7 +377,7 @@ describe("PutTransaction API", () => {
                 });
 
                 it("should return a list of objects that represent completed files for the transaction", async () => {
-                    await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                    await trx.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length).then(s => s.end(fileData.info));
                     await trx.finalize();
                     assert.equal(trx.files.length, 1);
                 });
@@ -386,12 +385,12 @@ describe("PutTransaction API", () => {
 
             describe("finalize", function() {
                 it("should return an error if any file was not fully written", async () => {
-                    await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info.slice(0, 1)));
+                    await trx.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length).then(s => s.end(fileData.info.slice(0, 1)));
                     await trx.finalize().then(() => { throw new Error("Expected error!"); }, err => assert(err));
                 });
 
                 it("should return with no error and no value if the transaction was successfully finalized", async () => {
-                    await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                    await trx.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length).then(s => s.end(fileData.info));
                     await trx.finalize();
                 });
 
@@ -417,25 +416,25 @@ describe("PutTransaction API", () => {
 
             describe("getWriteStream", function() {
                 it("should return a WritableStream for the given file type", () => {
-                    return trx.getWriteStream('i', 1)
+                    return trx.getWriteStream(consts.FILE_TYPE.INFO, 1)
                         .then(stream => assert(stream instanceof require('stream').Writable));
                 });
 
-                it("should only accept types of 'i', 'a', or 'r", async () => {
-                    await trx.getWriteStream('i', 1);
-                    await trx.getWriteStream('a', 1);
-                    await trx.getWriteStream('r', 1);
+                it("should only accept types of consts.FILE_TYPE.INFO, consts.FILE_TYPE.BIN, or 'r", async () => {
+                    await trx.getWriteStream(consts.FILE_TYPE.INFO, 1);
+                    await trx.getWriteStream(consts.FILE_TYPE.BIN, 1);
+                    await trx.getWriteStream(consts.FILE_TYPE.RESOURCE, 1);
                     await trx.getWriteStream('x', 1)
                         .then(() => { throw new Error("Expected error!"); }, err => assert(err));
                 });
 
                 it("should return an error for size equal to 0", () => {
-                    return trx.getWriteStream('i', 0)
+                    return trx.getWriteStream(consts.FILE_TYPE.INFO, 0)
                         .then(() => { throw new Error("Expected error!"); }, err => assert(err))
                 });
 
                 it("should return an error for size less than 0", () => {
-                    return trx.getWriteStream('i', -1)
+                    return trx.getWriteStream(consts.FILE_TYPE.INFO, -1)
                         .then(() => { throw new Error("Expected error!"); }, err => assert(err))
                 });
             });
@@ -448,7 +447,7 @@ describe("PutTransaction API", () => {
                 });
 
                 it("should cause files to return an empty array", async () => {
-                    await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                    await trx.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length).then(s => s.end(fileData.info));
                     await trx.finalize();
                     assert.equal(trx.files.length, 1);
                     await trx.invalidate();
@@ -458,7 +457,7 @@ describe("PutTransaction API", () => {
 
             describe("writeFilesToPath", () => {
                 it("should copy or write file data to the specified path", async () => {
-                    await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                    await trx.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length).then(s => s.end(fileData.info));
                     await trx.finalize();
                     const o = await tmp.dir({ unsafeCleanup: true });
                     const files = await trx.writeFilesToPath(o.path);

--- a/test/cache_base.js
+++ b/test/cache_base.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 const path = require('path');
 const randomBuffer = require('./test_utils').randomBuffer;
 const consts = require('../lib/constants');
+const sinon = require('sinon');
 
 describe("Cache: Base Class", () => {
     let cache;
@@ -130,9 +131,48 @@ describe("Cache: Base Class", () => {
     });
 
     describe("endPutTransaction", () => {
-        it("should require override implementation in subclasses by returning an error", () => {
-            return cache.endPutTransaction()
-                .then(() => { throw new Error("Expected error!"); }, () => {});
+        let stub;
+
+        after(() => {
+            stub.resetBehavior();
+        });
+
+        it("should call finalize on the transaction", async () => {
+            const trx = { finalize: () => {} };
+            const mock = sinon.mock(trx);
+            mock.expects("finalize").once();
+            await cache.endPutTransaction(trx);
+            mock.verify();
+        });
+
+        it("should process valid transactions with the reliability manager if high reliability mode is on", async () => {
+            const trx = {
+                finalize: () => {},
+                isValid: false
+            };
+
+            const myOpts = Object.assign({}, opts);
+            myOpts.highReliability = true;
+            myOpts.highReliabilityOptions = { reliabilityThreshold: 2 };
+
+            await cache.init(myOpts);
+            stub = sinon.stub(cache._rm, "processTransaction");
+
+            // invalid transaction, high reliability enabled: should not process
+            await cache.endPutTransaction(trx);
+            assert(stub.notCalled);
+            stub.resetHistory();
+
+            // valid transaction, high reliability enabled: should process
+            trx.isValid = true;
+            await cache.endPutTransaction(trx);
+            assert(stub.calledOnce);
+            stub.resetHistory();
+
+            // valid transaction, high reliability disabled: should not process
+            myOpts.highReliability = false;
+            await cache.endPutTransaction(trx);
+            assert(stub.notCalled);
         });
     });
 
@@ -145,9 +185,13 @@ describe("Cache: Base Class", () => {
 });
 
 describe("PutTransaction: Base Class", () => {
+    let trx;
     const guid = randomBuffer(consts.GUID_SIZE);
     const hash = randomBuffer(consts.HASH_SIZE);
-    const trx = new PutTransaction(guid, hash);
+
+    beforeEach(() => {
+        trx = new PutTransaction(guid, hash);
+    });
 
     describe("get guid", () => {
         it("should return the guid passed to the constructor", () => {
@@ -170,6 +214,44 @@ describe("PutTransaction: Base Class", () => {
     describe("get files", () => {
         it("should return an empty array", () => {
             assert.equal(trx.files.length, 0);
+        });
+    });
+
+    describe("get filesHashStr", () => {
+        it("should return a non-zero length string even if there are no files in the transaction", () => {
+            assert(trx.filesHashStr.length > 0);
+        });
+
+        it("should return a hash string that uniquely identifies the transaction file contents", () => {
+            Object.defineProperty(trx, "files", {
+                get: () => { return [
+                    { type: consts.FILE_TYPE.BIN, byteHash: randomBuffer(consts.HASH_SIZE) },
+                    { type: consts.FILE_TYPE.RESOURCE, byteHash: randomBuffer(consts.HASH_SIZE) },
+                    { type: consts.FILE_TYPE.INFO, byteHash: randomBuffer(consts.HASH_SIZE) }
+                ]}
+            });
+
+            const str1 = trx.filesHashStr;
+            const str2 = trx.filesHashStr;
+
+            assert(str1 !== str2);
+        });
+
+        it("should not include the info (i) file contents in the hash", () => {
+            const a = randomBuffer(consts.HASH_SIZE);
+            const r = randomBuffer(consts.HASH_SIZE);
+            Object.defineProperty(trx, "files", {
+                get: () => { return [
+                    { type: consts.FILE_TYPE.BIN, byteHash: a },
+                    { type: consts.FILE_TYPE.RESOURCE, byteHash: r },
+                    { type: consts.FILE_TYPE.INFO, byteHash: randomBuffer(consts.HASH_SIZE) }
+                ]}
+            });
+
+            const str1 = trx.filesHashStr;
+            const str2 = trx.filesHashStr;
+
+            assert(str1 === str2);
         });
     });
 

--- a/test/cache_base.js
+++ b/test/cache_base.js
@@ -93,6 +93,12 @@ describe("Cache: Base Class", () => {
             return cache.init(opts)
                 .then(() => fs.access(opts.cachePath));
         });
+
+        it("should initialize the _db object", async () => {
+            await cache.init(opts);
+            assert.notEqual(cache._db, null);
+        });
+
     });
 
     describe("shutdown", () => {
@@ -130,24 +136,9 @@ describe("Cache: Base Class", () => {
         });
     });
 
-    describe("registerClusterWorker", () => {
-        it("should require override implementation in subclasses by returning an error", () => {
-            let error;
-            try {
-                cache.registerClusterWorker();
-            }
-            catch(err) {
-                error = err;
-            }
-            finally {
-                assert(error);
-            }
-        });
-    });
-
     describe("cleanup", () => {
         it("should require override implementation in subclasses by returning an error", () => {
-            return cache.endPutTransaction()
+            return cache.cleanup()
                 .then(() => { throw new Error("Expected error!"); }, () => {});
         });
     });
@@ -193,6 +184,13 @@ describe("PutTransaction: Base Class", () => {
     describe("getWriteStream", () => {
         it("should require override implementation in subclasses by returning an error", () => {
             return trx.getWriteStream('i', 0)
+                .then(() => { throw new Error("Expected error!"); }, () => {});
+        });
+    });
+
+    describe("writeFilesToPath", () => {
+        it("should require override implementation in subclasses by returning an error", () => {
+            return trx.writeFilesToPath()
                 .then(() => { throw new Error("Expected error!"); }, () => {});
         });
     });

--- a/test/cache_base.js
+++ b/test/cache_base.js
@@ -183,7 +183,7 @@ describe("PutTransaction: Base Class", () => {
 
     describe("getWriteStream", () => {
         it("should require override implementation in subclasses by returning an error", () => {
-            return trx.getWriteStream('i', 0)
+            return trx.getWriteStream(consts.FILE_TYPE.INFO, 0)
                 .then(() => { throw new Error("Expected error!"); }, () => {});
         });
     });

--- a/test/cache_fs.js
+++ b/test/cache_fs.js
@@ -6,6 +6,7 @@ const sleep = require('./test_utils').sleep;
 const assert = require('assert');
 const moment = require('moment');
 const helpers = require('../lib/helpers');
+const consts = require('../lib/constants');
 
 const MIN_FILE_SIZE = 1024 * 5;
 const MAX_FILE_SIZE = MIN_FILE_SIZE;
@@ -28,11 +29,11 @@ const addFileToCache = async (atime) => {
     const tmpPath = tmp.tmpNameSync();
     await fs.writeFile(tmpPath, data.bin);
     const trx = await cache.createPutTransaction(data.guid, data.hash);
-    await trx.getWriteStream('a', data.bin.length).then(s => s.end(data.bin));
+    await trx.getWriteStream(consts.FILE_TYPE.BIN, data.bin.length).then(s => s.end(data.bin));
     await cache.endPutTransaction(trx);
     await sleep(50);
     await fs.unlink(tmpPath);
-    const info = await cache.getFileInfo('a', data.guid, data.hash);
+    const info = await cache.getFileInfo(consts.FILE_TYPE.BIN, data.guid, data.hash);
     await fs.utimes(info.filePath, atime, atime);
 
     const stats = await fs.stat(info.filePath);
@@ -209,7 +210,7 @@ describe("Cache: FS", () => {
             it("should cleanup temporary files", async () => {
                 const fileData = generateCommandData(MIN_FILE_SIZE, MAX_FILE_SIZE);
                 const trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
-                await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                await trx.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length).then(s => s.end(fileData.info));
                 await trx.finalize();
                 assert.equal(trx.files.length, 1);
                 const filePath = trx.files[0].file;

--- a/test/cache_fs.js
+++ b/test/cache_fs.js
@@ -2,28 +2,46 @@ const tmp = require('tmp');
 const fs = require('fs-extra');
 const Cache = require('../lib/cache/cache_fs');
 const generateCommandData = require('./test_utils').generateCommandData;
+const sleep = require('./test_utils').sleep;
 const assert = require('assert');
 const moment = require('moment');
+const helpers = require('../lib/helpers');
 
 const MIN_FILE_SIZE = 1024 * 5;
 const MAX_FILE_SIZE = MIN_FILE_SIZE;
 
 const cacheOpts = {
-    cachePath: tmp.tmpNameSync({}).toString()
+    cachePath: tmp.tmpNameSync({}).toString(),
+    persistenceOptions: {
+        autosave: false
+    },
+    highReliability: true,
+    highReliabilityOptions: {
+        reliabilityThreshold: 0
+    }
 };
 
 let cache;
 
 const addFileToCache = async (atime) => {
     const data = generateCommandData(MIN_FILE_SIZE, MAX_FILE_SIZE);
-    const tmpPath = tmp.tmpNameSync({dir: cacheOpts.cachePath});
+    const tmpPath = tmp.tmpNameSync();
     await fs.writeFile(tmpPath, data.bin);
-    const cacheFile = await cache._addFileToCache('a', data.guid, data.hash, tmpPath);
-    await fs.utimes(cacheFile, atime, atime);
+    const trx = await cache.createPutTransaction(data.guid, data.hash);
+    await trx.getWriteStream('a', data.bin.length).then(s => s.end(data.bin));
+    await cache.endPutTransaction(trx);
+    await sleep(50);
+    await fs.unlink(tmpPath);
+    const info = await cache.getFileInfo('a', data.guid, data.hash);
+    await fs.utimes(info.filePath, atime, atime);
 
-    const stats = await fs.stat(cacheFile);
+    const stats = await fs.stat(info.filePath);
     assert(moment(stats.atime).isSame(atime, 'second'), `${stats.atime} != ${atime}`);
-    return cacheFile;
+    return {
+        path: info.filePath,
+        guidStr: helpers.GUIDBufferToString(data.guid),
+        hashStr: data.hash.toString('hex')
+    };
 };
 
 describe("Cache: FS", () => {
@@ -49,9 +67,9 @@ describe("Cache: FS", () => {
 
                 await cache.cleanup(false);
 
-                assert(!await fs.pathExists(file1));
-                assert(!await fs.pathExists(file2));
-                assert(await fs.pathExists(file3));
+                assert(!await fs.pathExists(file1.path));
+                assert(!await fs.pathExists(file2.path));
+                assert(await fs.pathExists(file3.path));
             });
 
             it("should remove files that have not been accessed within a given timespan (ISO 8601 style)", async () => {
@@ -66,15 +84,15 @@ describe("Cache: FS", () => {
                 const file2 = await addFileToCache(moment().subtract(2, 'days').toDate());
                 const file3 = await addFileToCache(moment().toDate());
 
-                assert(await fs.pathExists(file1));
-                assert(await fs.pathExists(file2));
-                assert(await fs.pathExists(file3));
+                assert(await fs.pathExists(file1.path));
+                assert(await fs.pathExists(file2.path));
+                assert(await fs.pathExists(file3.path));
 
                 await cache.cleanup(false);
 
-                assert(!await fs.pathExists(file1));
-                assert(!await fs.pathExists(file2));
-                assert(await fs.pathExists(file3));
+                assert(!await fs.pathExists(file1.path));
+                assert(!await fs.pathExists(file2.path));
+                assert(await fs.pathExists(file3.path));
             });
 
             it("should reject a promise with an invalid timespan", () => {
@@ -101,22 +119,22 @@ describe("Cache: FS", () => {
                 const file2 = await addFileToCache(moment().subtract(1, 'days').toDate());
                 const file3 = await addFileToCache(moment().subtract(5, 'days').toDate());
 
-                assert(await fs.pathExists(file1));
-                assert(await fs.pathExists(file2));
-                assert(await fs.pathExists(file3));
+                assert(await fs.pathExists(file1.path));
+                assert(await fs.pathExists(file2.path));
+                assert(await fs.pathExists(file3.path));
 
                 await cache.cleanup(false);
 
-                assert(await fs.pathExists(file1));
-                assert(await fs.pathExists(file2));
-                assert(!await fs.pathExists(file3));
+                assert(await fs.pathExists(file1.path));
+                assert(await fs.pathExists(file2.path));
+                assert(!await fs.pathExists(file3.path));
 
                 opts.cleanupOptions.maxCacheSize = MIN_FILE_SIZE + 1;
                 cache._options = opts;
 
                 await cache.cleanup(false);
-                assert(await fs.pathExists(file1));
-                assert(!await fs.pathExists(file2));
+                assert(await fs.pathExists(file1.path));
+                assert(!await fs.pathExists(file2.path));
             });
 
             it("should emit events while processing files", async () => {
@@ -157,7 +175,47 @@ describe("Cache: FS", () => {
                 await cache.init(opts);
                 const file = await addFileToCache(moment().toDate());
                 cache.cleanup(true);
-                assert(await fs.pathExists(file));
+                assert(await fs.pathExists(file.path));
+            });
+
+            it("should remove versions from the reliability manager, when in high reliability mode", async () => {
+                const opts = Object.assign({}, cacheOpts);
+                opts.cleanupOptions = {
+                    expireTimeSpan: "P30D",
+                    maxCacheSize: 1
+                };
+
+                await cache.init(opts);
+                const file = await addFileToCache(moment().toDate());
+                let rmEntry = cache.reliabilityManager.getEntry(file.guidStr, file.hashStr);
+                assert(rmEntry);
+
+                await cache.cleanup(false);
+                rmEntry = cache.reliabilityManager.getEntry(file.guidStr, file.hashStr);
+                assert(!rmEntry);
+            });
+        });
+    });
+
+    describe("PutTransaction API", () => {
+
+        beforeEach(() => {
+            cache = new Cache();
+        });
+
+        afterEach(() => fs.remove(cacheOpts.cachePath));
+
+        describe("invalidate", () => {
+            it("should cleanup temporary files", async () => {
+                const fileData = generateCommandData(MIN_FILE_SIZE, MAX_FILE_SIZE);
+                const trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
+                await trx.getWriteStream('i', fileData.info.length).then(s => s.end(fileData.info));
+                await trx.finalize();
+                assert.equal(trx.files.length, 1);
+                const filePath = trx.files[0].file;
+                assert(fs.pathExistsSync(filePath));
+                await trx.invalidate();
+                assert(!fs.pathExistsSync(filePath));
             });
         });
     });

--- a/test/cache_ram.js
+++ b/test/cache_ram.js
@@ -6,6 +6,7 @@ const generateCommandData = require('./test_utils').generateCommandData;
 const sleep = require('./test_utils').sleep;
 const path = require('path');
 const assert = require('assert');
+const consts = require('../lib/constants');
 
 const MIN_FILE_SIZE = 1024 * 5;
 const MAX_FILE_SIZE = MIN_FILE_SIZE;
@@ -31,9 +32,9 @@ describe("Cache: RAM", () => {
     const fileData = generateCommandData(MIN_FILE_SIZE, MAX_FILE_SIZE);
 
     const writeFileDataToCache = async (fileData) => {
-        await cache._addFileToCache('i', fileData.guid, fileData.hash, fileData.info);
-        await cache._addFileToCache('a', fileData.guid, fileData.hash, fileData.bin);
-        await cache._addFileToCache('r', fileData.guid, fileData.hash, fileData.resource);
+        await cache._addFileToCache(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash, fileData.info);
+        await cache._addFileToCache(consts.FILE_TYPE.BIN, fileData.guid, fileData.hash, fileData.bin);
+        await cache._addFileToCache(consts.FILE_TYPE.RESOURCE, fileData.guid, fileData.hash, fileData.resource);
     };
 
     describe("Public API", () => {
@@ -56,7 +57,7 @@ describe("Cache: RAM", () => {
 
             it("should populate the _index and _pageMeta when a saved database is loaded from disk", async () => {
                 await cache.init(opts);
-                await cache._addFileToCache('i', fileData.guid, fileData.hash, fileData.info);
+                await cache._addFileToCache(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash, fileData.info);
                 await cache.shutdown();
                 await cache.init(opts);
 
@@ -69,7 +70,7 @@ describe("Cache: RAM", () => {
                 myOpts.persistence = false;
 
                 await cache.init(myOpts);
-                await cache._addFileToCache('i', fileData.guid, fileData.hash, fileData.info);
+                await cache._addFileToCache(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash, fileData.info);
                 await cache.shutdown();
                 await cache.init(myOpts);
 
@@ -81,12 +82,12 @@ describe("Cache: RAM", () => {
         describe("getFileStream", () => {
             it("should update the lastAccessTime of the requested file entry", async () => {
                 await cache.init(opts);
-                await cache._addFileToCache('i', fileData.guid, fileData.hash, fileData.info);
-                let info = await cache.getFileInfo('i', fileData.guid, fileData.hash);
+                await cache._addFileToCache(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash, fileData.info);
+                let info = await cache.getFileInfo(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash);
                 const prevTime = info.lastAccessTime;
                 await sleep(100);
-                await cache.getFileStream('i', fileData.guid, fileData.hash);
-                info = await cache.getFileInfo('i', fileData.guid, fileData.hash);
+                await cache.getFileStream(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash);
+                info = await cache.getFileInfo(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash);
                 assert(info.lastAccessTime > prevTime);
             });
         });
@@ -102,7 +103,7 @@ describe("Cache: RAM", () => {
                 cache._serializeInProgress = true;
                 await cache.init(opts);
                 const trx = await cache.createPutTransaction(fileData.guid, fileData.hash);
-                const stream = await trx.getWriteStream('i', fileData.info.length);
+                const stream = await trx.getWriteStream(consts.FILE_TYPE.INFO, fileData.info.length);
                 stream.end(fileData.info);
                 await cache.endPutTransaction(trx);
                 assert(ok);
@@ -112,7 +113,7 @@ describe("Cache: RAM", () => {
         describe("shutdown", () => {
             it("should serialize the database and page files to disk before returning", async () => {
                 await cache.init(opts);
-                await cache._addFileToCache('i', fileData.guid, fileData.hash, fileData.info);
+                await cache._addFileToCache(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash, fileData.info);
 
                 const pages = dirtyPages();
                 assert.equal(pages.length, 1);
@@ -164,7 +165,7 @@ describe("Cache: RAM", () => {
                 // Remove all files from the cache dir
                 await fs.emptyDir(opts.cachePath);
                 // Replace a single file
-                await cache._addFileToCache('i', fileData.guid, fileData.hash, randomBuffer(fileData.info.length));
+                await cache._addFileToCache(consts.FILE_TYPE.INFO, fileData.guid, fileData.hash, randomBuffer(fileData.info.length));
                 // Store the dirty page list again
                 dirty = dirtyPages();
                 // Serialize the cache again
@@ -238,15 +239,15 @@ describe("Cache: RAM", () => {
 
         describe("_reserveBlock", () => {
             it("should allocate an existing free block in an existing page when available", () => {
-                const key = Cache._calcIndexKey('a', randomBuffer(16), randomBuffer(16));
+                const key = Cache._calcIndexKey(consts.FILE_TYPE.BIN, randomBuffer(16), randomBuffer(16));
                 const block = cache._reserveBlock(key, MIN_FILE_SIZE);
                 assert.equal(cache._pageMeta.count(), 1);
                 assert.equal(block.size, MIN_FILE_SIZE);
             });
 
             it("should allocate a new free block to a new page when no free blocks are found in existing pages", () => {
-                const key1 = Cache._calcIndexKey('a', randomBuffer(16), randomBuffer(16));
-                const key2 = Cache._calcIndexKey('a', randomBuffer(16), randomBuffer(16));
+                const key1 = Cache._calcIndexKey(consts.FILE_TYPE.BIN, randomBuffer(16), randomBuffer(16));
+                const key2 = Cache._calcIndexKey(consts.FILE_TYPE.BIN, randomBuffer(16), randomBuffer(16));
                 cache._reserveBlock(key1, opts.pageSize); // Fill up the first free block
                 const block = cache._reserveBlock(key2, MIN_FILE_SIZE); // Should now allocate another
                 assert.equal(cache._pageMeta.count(), 2);
@@ -256,21 +257,21 @@ describe("Cache: RAM", () => {
             it("should re-allocate a LRU block when no free blocks are available and maxPageCount has been reached", async () => {
                 let firstBlock;
                 for(let x = 0; x < opts.maxPageCount; x++) {
-                    const key = Cache._calcIndexKey('a', randomBuffer(16), randomBuffer(16));
+                    const key = Cache._calcIndexKey(consts.FILE_TYPE.BIN, randomBuffer(16), randomBuffer(16));
                     const block = cache._reserveBlock(key, opts.pageSize);
                     if(!firstBlock)
                         firstBlock = block;
                     await sleep(50);
                 }
 
-                const key = Cache._calcIndexKey('a', randomBuffer(16), randomBuffer(16));
+                const key = Cache._calcIndexKey(consts.FILE_TYPE.BIN, randomBuffer(16), randomBuffer(16));
                 const block = cache._reserveBlock(key, MIN_FILE_SIZE);
                 assert.equal(firstBlock.pageIndex, block.pageIndex);
             });
 
             it("should throw an exception if no free block or no LRU block of a suitable size can be found when maxPageCount has been reached", () => {
                 for(let x = 0; x < opts.maxPageCount; x++) {
-                    const key = Cache._calcIndexKey('a', randomBuffer(16), randomBuffer(16));
+                    const key = Cache._calcIndexKey(consts.FILE_TYPE.BIN, randomBuffer(16), randomBuffer(16));
                     cache._reserveBlock(key, opts.pageSize);
                 }
 
@@ -281,10 +282,10 @@ describe("Cache: RAM", () => {
         describe("_addFileToCache", () => {
             it("should throw an error if the cache cannot grow to accommodate the new file", async () => {
                 for(let x = 0; x < opts.maxPageCount; x++) {
-                    await cache._addFileToCache('a', randomBuffer(16), randomBuffer(16), randomBuffer(opts.pageSize));
+                    await cache._addFileToCache(consts.FILE_TYPE.BIN, randomBuffer(16), randomBuffer(16), randomBuffer(opts.pageSize));
                 }
 
-                cache._addFileToCache('a', randomBuffer(16), randomBuffer(16), randomBuffer(opts.pageSize * 2))
+                cache._addFileToCache(consts.FILE_TYPE.BIN, randomBuffer(16), randomBuffer(16), randomBuffer(opts.pageSize * 2))
                     .then(() => { throw new Error("Expected exception!") }, () => {});
             });
         });

--- a/test/cache_ram.js
+++ b/test/cache_ram.js
@@ -23,7 +23,8 @@ describe("Cache: RAM", () => {
         minFreeBlockSize: 1024,
         persistenceOptions: {
             autosave: false
-        }
+        },
+        highReliability: false
     };
 
     let cache;
@@ -43,11 +44,6 @@ describe("Cache: RAM", () => {
         afterEach(() => fs.remove(opts.cachePath));
 
         describe("init", () => {
-            it("should initialize the _db object", async () => {
-                await cache.init(opts);
-                assert.notEqual(cache._db, null);
-            });
-
             it("should initialize an empty cache if no database was loaded from disk", async () => {
                 await cache.init(opts);
                 assert.equal(cache._pageMeta.count(), 1);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -58,7 +58,7 @@ describe("Helper functions", () => {
 
         it("should throw an error if the address can't be resolved", () => {
             return helpers.parseAndValidateAddressString("blah", 0)
-                .then(() => { throw new Error("Expected error"); }, err => {});
+                .then(() => { throw new Error("Expected error"); }, err => assert(err));
         });
     });
 

--- a/test/protocol.js
+++ b/test/protocol.js
@@ -32,6 +32,10 @@ const test_modules = [
         options: {
             pageSize: MAX_FILE_SIZE,
             minFreeBlockSize: 1024,
+            highReliability: true,
+            highReliabilityOptions: {
+                reliabilityThreshold: 0
+            },
             persistenceOptions: {
                 adapter: new loki.LokiMemoryAdapter()
             }
@@ -41,7 +45,12 @@ const test_modules = [
         tmpDir: tmp.dirSync({unsafeCleanup: true}),
         name: "cache_fs",
         path: "../lib/cache/cache_fs",
-        options: {}
+        options: {
+            highReliability: true,
+            highReliabilityOptions: {
+                reliabilityThreshold: 0
+            }
+        }
     }
     ];
 

--- a/test/protocol.js
+++ b/test/protocol.js
@@ -171,15 +171,15 @@ describe("Protocol", () => {
                             encodeCommand(cmd.transactionEnd), 'ascii');
 
                         await clientWrite(client, buf, test.packetSize);
-                        let stream = await cache.getFileStream('a', test.data.guid, test.data.hash);
+                        let stream = await cache.getFileStream(consts.FILE_TYPE.BIN, test.data.guid, test.data.hash);
                         let data = await readStream(stream, test.data.bin.length);
                         assert.strictEqual(test.data.bin.compare(data), 0);
 
-                        stream = await cache.getFileStream('i', test.data.guid, test.data.hash);
+                        stream = await cache.getFileStream(consts.FILE_TYPE.INFO, test.data.guid, test.data.hash);
                         data = await readStream(stream, test.data.info.length);
                         assert.strictEqual(test.data.info.compare(data), 0);
 
-                        stream = await cache.getFileStream('r', test.data.guid, test.data.hash);
+                        stream = await cache.getFileStream(consts.FILE_TYPE.RESOURCE, test.data.guid, test.data.hash);
                         data = await readStream(stream, test.data.resource.length);
                         assert.strictEqual(test.data.resource.compare(data), 0);
                     });
@@ -194,7 +194,7 @@ describe("Protocol", () => {
                         encodeCommand(cmd.transactionEnd), 'ascii');
 
                     return clientWrite(client, buf)
-                        .then(() => cache.getFileStream('a', self.data.guid, self.data.hash))
+                        .then(() => cache.getFileStream(consts.FILE_TYPE.BIN, self.data.guid, self.data.hash))
                         .then(stream => readStream(stream, self.data.bin.length))
                         .then(buffer => assert.strictEqual(buffer.compare(self.data.bin), 0));
                 });

--- a/test/reliability_manager.js
+++ b/test/reliability_manager.js
@@ -1,0 +1,212 @@
+const loki = require('lokijs');
+const tmp = require('tmp-promise');
+const randomBuffer = require('./test_utils').randomBuffer;
+const consts = require('../lib/constants');
+const helpers = require('../lib/helpers');
+const assert = require('assert');
+const sinon = require('sinon');
+const crypto = require('crypto');
+const { ReliabilityManager, PutTransaction } = require('../lib');
+
+class UnstablePutTransaction extends PutTransaction {
+    get filesHashStr() {
+        return crypto.randomBytes(64).toString('hex');
+    }
+
+    writeFilesToPath(path) {}
+}
+
+class StablePutTransaction extends PutTransaction {
+    get filesHashStr() {
+        return "abc123";
+    }
+}
+
+describe("ReliabilityManager", () => {
+    let rm, db;
+    before(() => {
+        const tmpDir = tmp.tmpNameSync();
+        db = new loki('test.db');
+        rm = new ReliabilityManager(db, tmpDir, {reliabilityThreshold: 2, saveUnreliableVersionArtifacts: true});
+    });
+
+    after(() => {
+        db.close();
+    });
+
+    describe("processTransaction", () => {
+        describe("Unknown version", () => {
+            let trx, trxSpy;
+            before(async () => {
+                const guid = randomBuffer(consts.GUID_SIZE);
+                const hash = randomBuffer(consts.HASH_SIZE);
+                trx = new PutTransaction(guid, hash);
+                trxSpy = sinon.spy(trx, "writeFilesToPath");
+                assert(trx.isValid);
+                await rm.processTransaction(trx);
+            });
+
+            it("should create a new version entry with the correct reliability state", async () => {
+                const entry = rm.getEntry(helpers.GUIDBufferToString(trx.guid), trx.hash.toString('hex'));
+                assert(entry);
+                assert.strictEqual(entry.factor, 1);
+                assert.strictEqual(entry.state, ReliabilityManager.reliabilityStates.Pending);
+            });
+
+            it("should invalidate the transaction", async () => {
+                assert(!trx.isValid);
+            });
+
+            it("should not tell the transaction write unreliable files", () => {
+                assert(!trxSpy.called);
+            });
+        });
+
+        describe("Known version, reliabilityFactor meets reliabilityThreshold", () => {
+            let trx, trxSpy;
+            before(async () => {
+                const guid = randomBuffer(consts.GUID_SIZE);
+                const hash = randomBuffer(consts.HASH_SIZE);
+                await rm.processTransaction(new StablePutTransaction(guid, hash)); // once
+                trx = new StablePutTransaction(guid, hash);
+                trxSpy = sinon.spy(trx, "writeFilesToPath");
+                assert(trx.isValid);
+                await rm.processTransaction(trx); // twice (last time)
+            });
+
+            it("should increment the reliability factor & set the correct reliability state", () => {
+                const entry = rm.getEntry(helpers.GUIDBufferToString(trx.guid), trx.hash.toString('hex'));
+                assert(entry);
+                assert.strictEqual(entry.factor, 2);
+                assert.strictEqual(entry.state, ReliabilityManager.reliabilityStates.ReliableNew);
+            });
+
+            it("should not invalidate the transaction", () => {
+                assert(trx.isValid);
+            });
+
+            it("should not tell the cache to write unreliable files", () => {
+                assert(!trxSpy.called);
+            });
+        });
+
+        describe("Known version, reliabilityFactor exceeds reliabilityThreshold", () => {
+            let trx;
+            before(async () => {
+                const guid = randomBuffer(consts.GUID_SIZE);
+                const hash = randomBuffer(consts.HASH_SIZE);
+                await rm.processTransaction(new StablePutTransaction(guid, hash)); // once
+                await rm.processTransaction(new StablePutTransaction(guid, hash)); // twice
+                trx = new StablePutTransaction(guid, hash);
+                assert(trx.isValid);
+                await rm.processTransaction(trx); // three times (last time)
+            });
+
+            it("should not change the reliabilityFactor, regardless of versionHash consistency", () => {
+                const entry = rm.getEntry(helpers.GUIDBufferToString(trx.guid), trx.hash.toString('hex'));
+                assert(entry);
+                assert.strictEqual(entry.factor, 2);
+                assert.strictEqual(entry.state, ReliabilityManager.reliabilityStates.Reliable);
+            });
+
+            it("should invalidate the transaction to prevent changes to the version", () => {
+                assert(!trx.isValid);
+            });
+        });
+
+        describe("Known version, inconsistent versionHash", () => {
+            let trx, spy;
+            before(async () => {
+                const guid = randomBuffer(consts.GUID_SIZE);
+                const hash = randomBuffer(consts.HASH_SIZE);
+                await rm.processTransaction(new UnstablePutTransaction(guid, hash)); // once
+
+                trx = await new UnstablePutTransaction(guid, hash);
+                spy = sinon.spy(trx, "writeFilesToPath");
+                assert(trx.isValid);
+                await rm.processTransaction(trx); // twice (last time)
+            });
+
+            it("should set the correct reliability state", () => {
+                const entry = rm.getEntry(helpers.GUIDBufferToString(trx.guid), trx.hash.toString('hex'));
+                assert(entry);
+                assert.strictEqual(entry.state, ReliabilityManager.reliabilityStates.Unreliable);
+            });
+
+            it("should invalidate the transaction", () => {
+                assert(!trx.isValid);
+            });
+
+            it("should tell the transaction to write unreliable files if saveUnreliableVersionArtifacts is true", async () => {
+                assert(spy.called);
+
+                // Test with saveUnreliableVersionArtifacts = false
+                const myRm = new ReliabilityManager(db, tmp.tmpNameSync(), {reliabilityThreshold: 2, saveUnreliableVersionArtifacts: false});
+                spy.resetHistory();
+                await myRm.processTransaction(trx);
+                assert(!spy.called);
+            });
+        });
+
+        describe("requireUniqueClients", () => {
+            it("should not increment the reliability factor twice in a row for the same client", async () => {
+                const myRm = new ReliabilityManager(db, tmp.tmpNameSync(), { reliabilityThreshold: 2, requireUniqueClients: true });
+                const guid = randomBuffer(consts.GUID_SIZE);
+                const hash = randomBuffer(consts.HASH_SIZE);
+                await myRm.processTransaction(new StablePutTransaction(guid, hash));
+
+                const trx = new StablePutTransaction(guid, hash);
+                trx.clientAddress = "A";
+                await myRm.processTransaction(trx);
+
+                const entry = rm.getEntry(helpers.GUIDBufferToString(trx.guid), trx.hash.toString('hex'));
+                assert.equal(entry.state, ReliabilityManager.reliabilityStates.Pending);
+
+                trx.clientAddress = "B";
+                await myRm.processTransaction(trx);
+                assert.equal(entry.state, ReliabilityManager.reliabilityStates.ReliableNew);
+            });
+        });
+    });
+
+    describe("getEntry", () => {
+        it("should retrieve an entry for a given asset GUID & Hash", async () => {
+            const guidStr = randomBuffer(consts.GUID_SIZE);
+            const hashStr = randomBuffer(consts.HASH_SIZE);
+            await rm.processTransaction(new StablePutTransaction(guidStr, hashStr));
+            const entry = rm.getEntry(helpers.GUIDBufferToString(guidStr), hashStr.toString('hex'));
+            assert(entry);
+            assert(entry.versionHash.length > 0);
+            assert(entry.factor > 0);
+        });
+
+        it("should not create a new entry for an unknown GUID & Hash when create == false", () => {
+            const guidStr = helpers.GUIDBufferToString(randomBuffer(consts.GUID_SIZE));
+            const hashStr = randomBuffer(consts.HASH_SIZE).toString('hex');
+            const entry = rm.getEntry(guidStr, hashStr, false);
+            assert(!entry);
+        });
+
+        it("should create a new entry with a factor of 0 for an unknown GUID & Hash when create == true", () => {
+            const guidStr = helpers.GUIDBufferToString(randomBuffer(consts.GUID_SIZE));
+            const hashStr = randomBuffer(consts.HASH_SIZE).toString('hex');
+            const entry = rm.getEntry(guidStr, hashStr, true);
+            assert(entry);
+            assert.strictEqual(entry.factor, 0);
+            assert(!entry.versionHash);
+        });
+    });
+
+
+    describe("removeEntry", () => {
+        it("should remove the entry for a given GUID & Hash", () => {
+            const guidStr = helpers.GUIDBufferToString(randomBuffer(consts.GUID_SIZE));
+            const hashStr = randomBuffer(consts.HASH_SIZE).toString('hex');
+            let entry = rm.getEntry(guidStr, hashStr, true);
+            assert(entry);
+            rm.removeEntry(guidStr, hashStr);
+            entry = rm.getEntry(guidStr, hashStr);
+            assert(!entry);
+        });
+    });
+});

--- a/test/reliability_manager.js
+++ b/test/reliability_manager.js
@@ -153,13 +153,16 @@ describe("ReliabilityManager", () => {
                 const myRm = new ReliabilityManager(db, tmp.tmpNameSync(), { reliabilityThreshold: 2, multiClient: true });
                 const guid = randomBuffer(consts.GUID_SIZE);
                 const hash = randomBuffer(consts.HASH_SIZE);
-                await myRm.processTransaction(new StablePutTransaction(guid, hash));
 
                 const trx = new StablePutTransaction(guid, hash);
                 trx.clientAddress = "A";
                 await myRm.processTransaction(trx);
 
                 const entry = rm.getEntry(helpers.GUIDBufferToString(trx.guid), trx.hash.toString('hex'));
+                assert.equal(entry.state, ReliabilityManager.reliabilityStates.Pending);
+
+                trx.clientAddress = "A";
+                await myRm.processTransaction(trx);
                 assert.equal(entry.state, ReliabilityManager.reliabilityStates.Pending);
 
                 trx.clientAddress = "B";

--- a/test/reliability_manager.js
+++ b/test/reliability_manager.js
@@ -148,9 +148,9 @@ describe("ReliabilityManager", () => {
             });
         });
 
-        describe("requireUniqueClients", () => {
+        describe("multiClient", () => {
             it("should not increment the reliability factor twice in a row for the same client", async () => {
-                const myRm = new ReliabilityManager(db, tmp.tmpNameSync(), { reliabilityThreshold: 2, requireUniqueClients: true });
+                const myRm = new ReliabilityManager(db, tmp.tmpNameSync(), { reliabilityThreshold: 2, multiClient: true });
                 const guid = randomBuffer(consts.GUID_SIZE);
                 const hash = randomBuffer(consts.HASH_SIZE);
                 await myRm.processTransaction(new StablePutTransaction(guid, hash));


### PR DESCRIPTION
Added new feature, High Reliablity mode. For details see the documentation added to the README.md file in this PR.

A few supporting refactors are included here:
* Moved the loki.js database handling to the  base Cache class (from CacheRAM), so now any cache module can use the in-memory DB for storage. This was necessary to give CacheFS a facility for tracking reliability factors for versions
* Added a small utility class to handle cluster messaging, to facilitate worker nodes reading and writing to the in-memory database on the master node. This messaging class doesn't have test coverage yet - I haven't cracked the nut on properly testing forked clients with Mocha (and getting code coverage with Istanbul).
* Consolidated all of the string literals for file types into constants