### PR TITLE
[pr] Fix Timestamp Comparison

### DIFF
--- a/import.js
+++ b/import.js
@@ -94,7 +94,7 @@ async function importTransactionFile(filePath, addressString, defaultPort) {
                 continue;
             }
 
-            if (program.timestampCheck && stats.mtimeMs !== file.ts * 1000) {
+            if (program.timestampCheck && Math.trunc(stats.mtimeMs / 1000) !== file.ts) {
                 warns.push(`${file.path} has been modified, skipping`);
                 continue;
             }


### PR DESCRIPTION
`file.ts` is in seconds, and `stats.mtimeMs` is in milliseconds. Comparing in milliseconds was not working, since `file.ts` has less significant digits. 
Rounding `stats.mtimeMs` to seconds instead should fix this.
