### PR TITLE
NullStream write after end fix

### DIFF
--- a/lib/server/command_processor.js
+++ b/lib/server/command_processor.js
@@ -9,15 +9,6 @@ const kSource = Symbol("source");
 const kCache = Symbol("cache");
 const kSendFileQueue = Symbol("sendFileQueue");
 
-class NullStream extends Writable {
-    _write(chunk, encoding, cb) {
-        setImmediate(cb);
-    }
-    end(chunk, encoding, cb) {
-        if(cb) setImmediate(cb);
-    }
-}
-
 class CommandProcessor extends Duplex {
 
     /**
@@ -48,7 +39,6 @@ class CommandProcessor extends Duplex {
         this._putWhitelist = this._options.putWhitelist;
         this._whitelistEmpty = (!Array.isArray(this._putWhitelist) || !this._putWhitelist.length);
 
-        this._nullStream = new NullStream();
         this._putStream = null;
         this._putSize = 0;
         this._putSent = 0;
@@ -354,7 +344,11 @@ class CommandProcessor extends Duplex {
         if (this._isWhitelisted(this._trx.clientAddress)) {
             this._putStream = await this._trx.getWriteStream(type, size);
         } else {
-            this._putStream = this._nullStream;
+            this._putStream = new Writable({
+                write(chunk, encoding, cb) {
+                    setImmediate(cb);
+                }
+            });
             helpers.log(consts.LOG_DBG, `PUT rejected from non-whitelisted IP: ${this._trx.clientAddress}`);
         }
 

--- a/lib/server/command_processor.js
+++ b/lib/server/command_processor.js
@@ -13,6 +13,9 @@ class NullStream extends Writable {
     _write(chunk, encoding, cb) {
         setImmediate(cb);
     }
+    end(chunk, encoding, cb) {
+        if(cb) setImmediate(cb);
+    }
 }
 
 class CommandProcessor extends Duplex {


### PR DESCRIPTION
Since the stream needs to be reused, make it bypass the normal end process and just keep on eating put requests.