### PR TITLE
Fix for issue #75 - Cache Server should not allow file overwrites during reads

### DIFF
--- a/lib/cache/cache_fs.js
+++ b/lib/cache/cache_fs.js
@@ -9,10 +9,24 @@ const moment = require('moment');
 const pick = require('lodash').pick;
 const crypto = require('crypto');
 const fileExtensions = require('lodash').invert(consts.FILE_TYPE);
+const cluster = require('cluster');
+const cm = require('../cluster_messages');
+
+const k_incrementGuidRef = "_incrementGuidRef";
+const k_releaseGuidRef = "_releaseGuidRef";
 
 class CacheFS extends CacheBase {
     constructor() {
         super();
+        this._guidRefs = {};
+
+        cm.listenFor(k_incrementGuidRef, key => {
+            this._incrementGuidRef(key);
+        });
+
+        cm.listenFor(k_releaseGuidRef, key => {
+            this._releaseGuidRef(key);
+        });
     }
 
     get _optionsPath() {
@@ -53,6 +67,39 @@ class CacheFS extends CacheBase {
 
     /**
      *
+     * @param {String} key
+     * @private
+     */
+    _incrementGuidRef(key) {
+        if(cluster.isWorker) {
+            return cm.send(k_incrementGuidRef, key);
+        }
+
+        if(this._guidRefs.hasOwnProperty(key)) {
+            this._guidRefs[key]++;
+        }
+        else {
+            this._guidRefs[key] = 1;
+        }
+    }
+
+    /**
+     *
+     * @param {String} key
+     * @private
+     */
+    _releaseGuidRef(key) {
+        if(cluster.isWorker) {
+            return cm.send(k_releaseGuidRef, key);
+        }
+
+        if(this._guidRefs.hasOwnProperty(key)) {
+            this._guidRefs[key]--;
+        }
+    }
+
+    /**
+     *
      * @param {String} type
      * @param {Buffer} guid
      * @param {Buffer} hash
@@ -64,8 +111,22 @@ class CacheFS extends CacheBase {
         return path.join(this._cachePath, fileName.substr(0, 2), fileName);
     }
 
+    /**
+     *
+     * @param {String} type
+     * @param {Buffer} guid
+     * @param {Buffer} hash
+     * @param {String} sourcePath
+     * @returns {Promise<String>}
+     * @private
+     */
     async _writeFileToCache(type, guid, hash, sourcePath) {
         const filePath = this._calcFilepath(type, guid, hash);
+
+        if(this._guidRefs.hasOwnProperty(filePath) && this._guidRefs[filePath] > 0) {
+            throw new Error(`File is busy, cannot overwrite ${key}`);
+        }
+
         await fs.move(sourcePath, filePath, { overwrite: true });
         return filePath;
     }
@@ -77,13 +138,18 @@ class CacheFS extends CacheBase {
     }
 
     getFileStream(type, guid, hash) {
-        const stream = fs.createReadStream(this._calcFilepath(type, guid, hash));
+        const key = this._calcFilepath(type, guid, hash);
+        const stream = fs.createReadStream(key);
 
         return new Promise((resolve, reject) => {
-            stream.on('open', () => resolve(stream))
-                .on('error', err => {
+            stream.on('open', () => {
+                this._incrementGuidRef(key);
+                resolve(stream);
+            }).on('error', err => {
                 helpers.log(consts.LOG_ERR, err);
                 reject(err);
+            }).on('close', () => {
+                this._releaseGuidRef(key);
             });
         });
     }
@@ -96,17 +162,11 @@ class CacheFS extends CacheBase {
         const self = this;
         await super.endPutTransaction(transaction);
 
-        return Promise.all(
-            transaction.files.map(async (file) => {
-                try {
-                    const filePath = await self._writeFileToCache(file.type, transaction.guid, transaction.hash, file.file);
-                    helpers.log(consts.LOG_TEST, `Added file to cache: ${file.size} ${filePath}`);
-                }
-                catch(err) {
-                    helpers.log(consts.LOG_DBG, err);
-                }
-            })
-        );
+        const promises = transaction.files.map((file) =>
+            self._writeFileToCache(file.type, transaction.guid, transaction.hash, file.file)
+                .then(filePath => helpers.log(consts.LOG_TEST, `Added file to cache: ${file.size} ${filePath}`)));
+
+        return Promise.all(promises);
     }
 
     async cleanup(dryRun = true) {

--- a/lib/cache/cache_ram.js
+++ b/lib/cache/cache_ram.js
@@ -168,7 +168,7 @@ class CacheRAM extends CacheBase {
         const key = CacheRAM._calcIndexKey(type, guid, hash);
 
         if(this._guidRefs.hasOwnProperty(key) && this._guidRefs[key] > 0) {
-            await new Promise(resolve => this.once(`guidRefRelease-${key}`, resolve));
+            throw new Error(`File is busy, cannot overwrite ${key}`);
         }
 
         const entry = this._reserveBlock(key, buffer.length);
@@ -303,12 +303,7 @@ class CacheRAM extends CacheBase {
             this._guidRefs[key] = 1;
         }
 
-        stream.on('end', () => {
-            this._guidRefs[key]--;
-            if(this._guidRefs[key] === 0) {
-                this.emit(`guidRefRelease-${key}`);
-            }
-        });
+        stream.on('end', () => this._guidRefs[key]--);
 
         return stream;
     }
@@ -321,10 +316,8 @@ class CacheRAM extends CacheBase {
         await this._waitForSerialize();
         await super.endPutTransaction(transaction);
 
-        for(const file of transaction.files) {
-            this._addFileToCache(file.type, transaction.guid, transaction.hash, file.buffer)
-                .catch(err => helpers.log(consts.LOG_ERR, err));
-        }
+        const promises = transaction.files.map(file => this._addFileToCache(file.type, transaction.guid, transaction.hash, file.buffer));
+        return Promise.all(promises);
     }
 
     cleanup(dryRun = true) {

--- a/test/cache_api.js
+++ b/test/cache_api.js
@@ -147,7 +147,7 @@ describe("Cache API", function() {
                         .then(() => { throw new Error("Expected error!"); }, err =>  assert(err));
                 });
 
-                it("should handle files being replaced while read streams to the same file are already open", async () => {
+                it("should throw an error when trying to replace a file that is open for reading", async () => {
                     const TEST_FILE_SIZE = 1024 * 64 * 2;
 
                     const fData = generateCommandData(TEST_FILE_SIZE, TEST_FILE_SIZE);
@@ -157,34 +157,20 @@ describe("Cache API", function() {
                     let wStream = await trx.getWriteStream(consts.FILE_TYPE.INFO, fData.info.length);
                     await new Promise(resolve => wStream.end(fData.info, resolve));
                     await cache.endPutTransaction(trx);
-                    await sleep(50);
 
                     // Get a read stream
-                    let rStream = await cache.getFileStream(consts.FILE_TYPE.INFO, fData.guid, fData.hash);
+                    const rStream = await cache.getFileStream(consts.FILE_TYPE.INFO, fData.guid, fData.hash);
 
-                    // Read a block
-                    let buf = Buffer.allocUnsafe(fData.info.length);
-                    let bytes = await new Promise(resolve => rStream.once('readable', () => resolve(rStream.read(1024 * 64))));
-                    bytes.copy(buf, 0, 0);
+                    // Read a byte
+                    await new Promise(resolve => rStream.once('readable', () => resolve(rStream.read(1))));
 
-                    // Replace the file (use the resource data)
+                    // Try to replace the file (use the resource data)
                     trx = await cache.createPutTransaction(fData.guid, fData.hash);
                     wStream = await trx.getWriteStream(consts.FILE_TYPE.INFO, fData.resource.length);
                     await new Promise(resolve => wStream.end(fData.resource, resolve));
-                    await cache.endPutTransaction(trx);
-                    await sleep(50);
 
-                    // Read the rest of the file - compare it to the info data
-                    bytes = await readStream(rStream, fData.info.length - bytes.length);
-                    bytes.copy(buf, fData.info.length - bytes.length, 0);
-                    assert.equal(buf.compare(fData.info), 0);
-
-                    // Get another new read stream to the same guid
-                    rStream = await cache.getFileStream(consts.FILE_TYPE.INFO, fData.guid, fData.hash);
-
-                    // Read the file and compare it to the resource data
-                    buf = await readStream(rStream, fData.resource.length);
-                    assert.equal(buf.compare(fData.resource), 0);
+                    cache.endPutTransaction(trx).then(() => { throw new Error("Expected error"); }, (err) => assert(err))
+                        .then(() => rStream.destroy());
                 });
 
                 describe("High Reliability Mode", () => {


### PR DESCRIPTION
This change does two things:
1) Fixes an incorrect async method call in cache_ram (calling `_addFileToCache()` synchronously), which was causing a false positive for a test that was presuming to allow version overwrites while the same version was being sent to a different client
2) Refactors to no longer allow this behavior in cache_fs, which requires adding a higher level file locking mechanism (borrowing from cache_ram).

To restate a different way in case this isn't really clear: fixing the async call in cache_ram caused a previously passing test to fail - and I've determined the best way to fix the failing test is to prevent the tested behavior in cache_fs, thus inverting the test.