### PR TITLE
Bugfix/close open files on disconnect

### DIFF
--- a/lib/server/command_processor.js
+++ b/lib/server/command_processor.js
@@ -7,6 +7,7 @@ const { promisify } = require('util');
 const kSource = Symbol("source");
 const kCache = Symbol("cache");
 const kSendFileQueue = Symbol("sendFileQueue");
+const kReadStream = Symbol("readStream");
 
 class CommandProcessor extends Duplex {
 
@@ -18,6 +19,7 @@ class CommandProcessor extends Duplex {
         super();
         this[kCache] = cache;
         this[kSendFileQueue] = [];
+        this[kReadStream] = null;
 
         this._writeHandlers = {
             putStream: this._handleWrite.bind(this),
@@ -56,10 +58,20 @@ class CommandProcessor extends Duplex {
     }
 
     _registerEventListeners() {
-        const self = this;
         this.once('finish', this._printReadStats);
         this.on('pipe', src => {
-            self[kSource] = src;
+            this[kSource] = src;
+        });
+
+        this.on('unpipe', () => {
+            this[kSource] = null;
+            this[kSendFileQueue] = [];
+
+            if(this[kReadStream]) {
+                helpers.log(consts.LOG_DBG, "Destroying cache file readStream");
+                this[kReadStream].destroy();
+                this[kReadStream] = null;
+            }
         });
     }
 
@@ -117,6 +129,7 @@ class CommandProcessor extends Duplex {
 
         try {
             stream = await this[kCache].getFileStream(file.type, file.guid, file.hash);
+            this[kReadStream] = stream;
         }
         catch(err) {
             helpers.log(consts.LOG_ERR, err);
@@ -124,35 +137,37 @@ class CommandProcessor extends Duplex {
             return;
         }
 
-        const self = this;
-
-        function readChunk() {
-            if(!self._readReady) {
-                return setImmediate(readChunk);
+        const readChunk = () => {
+            if(!this._readReady) {
+                return stream.destroyed || this[kSource] == null
+                    ? endRead()
+                    : setImmediate(readChunk);
             }
 
             let chunk;
             while(chunk = stream.read()) {
-                self._readReady = self.push(chunk, 'ascii');
-                self._sendFileQueueChunkReads++;
-                self._sendFileQueueReadBytes += chunk.length;
+                this._readReady = this.push(chunk, 'ascii');
+                this._sendFileQueueChunkReads++;
+                this._sendFileQueueReadBytes += chunk.length;
 
-                if(!self._readReady) {
+                if(!this._readReady) {
                     setImmediate(readChunk);
                     break;
                 }
             }
-        }
+        };
+
+        const endRead = () => {
+            this[kReadStream] = null;
+            this[kSendFileQueue].shift();
+            this._sendFileQueueSentCount++;
+            this._isReading = false;
+            this._sendFileQueueReadDuration += Date.now() - this._readStartTime;
+            this._read();
+        };
 
         stream.on('readable', readChunk);
-
-        stream.on('end', () => {
-            self[kSendFileQueue].shift();
-            self._sendFileQueueSentCount++;
-            self._isReading = false;
-            self._sendFileQueueReadDuration += Date.now() - self._readStartTime;
-            self._read();
-        });
+        stream.on('end', () => endRead);
     }
 
     /**
@@ -172,11 +187,11 @@ class CommandProcessor extends Duplex {
      * @private
      */
    async _quit(err) {
+        this[kSource].emit('quit');
        this[kSource].unpipe(this);
-       this[kSource].emit('quit');
        this._writeHandler = this._writeHandlers.none;
        if(err) {
-           helpers.log(consts.LOG_ERR, err);
+           helpers.log(consts.LOG_ERR, err.message);
        }
     }
 

--- a/lib/server/command_processor.js
+++ b/lib/server/command_processor.js
@@ -187,7 +187,7 @@ class CommandProcessor extends Duplex {
      * @private
      */
    async _quit(err) {
-        this[kSource].emit('quit');
+       this[kSource].emit('quit');
        this[kSource].unpipe(this);
        this._writeHandler = this._writeHandlers.none;
        if(err) {

--- a/lib/server/command_processor.js
+++ b/lib/server/command_processor.js
@@ -167,7 +167,7 @@ class CommandProcessor extends Duplex {
         };
 
         stream.on('readable', readChunk);
-        stream.on('end', () => endRead);
+        stream.on('end', endRead);
     }
 
     /**

--- a/test/protocol.js
+++ b/test/protocol.js
@@ -261,6 +261,17 @@ describe("Protocol", () => {
                     });
                 });
 
+                it("should gracefully handle an abrupt socket close when sending a file", function(done) {
+                    const resp = new CacheServerResponseTransform();
+                    resp.on('data', () => {});
+                    client.pipe(resp);
+                    const buf = Buffer.from(encodeCommand(cmd.getAsset, self.data.guid, self.data.hash) +
+                        encodeCommand(cmd.quit), 'ascii');
+                    client.write(buf, () => done());
+                    // There's no assertion here - the failure would manifest as a stuck/hung test process as a result
+                    // of a stuck async loop
+                });
+
                 const tests = [
                     {cmd: cmd.getAsset, blob: self.data.bin, type: 'bin', packetSize: SMALL_PACKET_SIZE},
                     {cmd: cmd.getInfo, blob: self.data.info, type: 'info', packetSize: MED_PACKET_SIZE},

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -123,8 +123,9 @@ exports.readStream = function(stream, size) {
         stream.on('readable', function() {
             let data;
             while(data = this.read()) {
-                if(pos + data.length > size)
+                if(pos + data.length > size) {
                     reject(new Error("Stream size exceeds buffer size allocation"));
+                }
 
                 data.copy(buffer, pos);
                 pos += data.length;

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -120,13 +120,14 @@ exports.readStream = function(stream, size) {
     return new Promise((resolve, reject) => {
         let pos = 0;
         const buffer = Buffer.alloc(size, 0, 'ascii');
-        stream.on('data', data => {
-            if(pos + data.length <= size) {
+        stream.on('readable', function() {
+            let data;
+            while(data = this.read()) {
+                if(pos + data.length > size)
+                    reject(new Error("Stream size exceeds buffer size allocation"));
+
                 data.copy(buffer, pos);
                 pos += data.length;
-            }
-            else {
-                reject(new Error("Stream size exceeds buffer size allocation"));
             }
         });
 


### PR DESCRIPTION
Fix Issue #69: ensure that open file streams are closed if the socket is destroyed
Fix Issue #68: fixed infinite setTimeout loop when socket is destroyed during a file read