### PR TITLE
Feature/file read refactor

### DIFF
--- a/lib/server/command_processor.js
+++ b/lib/server/command_processor.js
@@ -142,7 +142,6 @@ class CommandProcessor extends Duplex {
     _read() {
         // Continue file read in progress
         if(this._isReading) {
-            this._readChunk();
             return;
         }
 
@@ -154,6 +153,7 @@ class CommandProcessor extends Duplex {
         // De-queue the next file
         const file = this[kSendFileQueue].shift();
 
+        // Respond with file-not-found header and early out, wait for next _read
         if(!file.exists) {
             this.push(this._responseHeader(file), 'ascii');
             return;
@@ -170,11 +170,11 @@ class CommandProcessor extends Duplex {
                 this.push(this._responseHeader(file), 'ascii');
                 this[kReadStream].on('readable', this._readChunk.bind(this));
                 this[kReadStream].once('end', this._endRead.bind(this));
-            }, err => {
+            }).catch(err => {
                 helpers.log(consts.LOG_ERR, `Error reading file for GUID: ${helpers.GUIDBufferToString(file.guid)} Hash: ${file.hash.toString('hex')}`);
                 helpers.log(consts.LOG_ERR, err.message);
                 this._isReading = false;
-                file.exists = false;
+                file.exists = false; // generate a file-not-found response header
                 this.push(this._responseHeader(file), 'ascii');
             });
     }

--- a/lib/server/command_processor.js
+++ b/lib/server/command_processor.js
@@ -115,6 +115,8 @@ class CommandProcessor extends Duplex {
      * @private
      */
     _endRead() {
+        // Conditionally skipping setting this to null under test to reliably simulate a client dropping connection
+        // during a file read. This ensures the `destroy()` logic during the unpipe event handler is called on the open stream.
         if(!this._testReadStreamDestroy) this[kReadStream] = null;
         this._isReading = false;
         this._sendFileQueueSentCount++;

--- a/lib/server/command_processor.js
+++ b/lib/server/command_processor.js
@@ -54,8 +54,16 @@ class CommandProcessor extends Duplex {
         this._sendFileQueueCount = 0;
         this._sendFileQueueSentCount = 0;
         this._isReading = false;
-        this._readReady = true;
+        this._testReadStreamDestroy = false;
         this._registerEventListeners();
+    }
+
+    /**
+     *
+     * @returns {ReadStream}
+     */
+    get readStream() {
+        return this[kReadStream];
     }
 
     _registerEventListeners() {
@@ -69,9 +77,9 @@ class CommandProcessor extends Duplex {
             this[kSendFileQueue] = [];
 
             if(this[kReadStream]) {
-                helpers.log(consts.LOG_DBG, "Destroying cache file readStream");
                 this[kReadStream].destroy();
                 this[kReadStream] = null;
+                if(this._testReadStreamDestroy) this.emit('_testReadStreamDestroy');
             }
         });
     }
@@ -92,9 +100,83 @@ class CommandProcessor extends Duplex {
     /**
      * @private
      */
+    _readChunk() {
+        if(this[kReadStream] === null || this[kSource] === null) return;
+
+        let chunk;
+        while(chunk = this[kReadStream].read()) {
+            this._sendFileQueueChunkReads++;
+            this._sendFileQueueReadBytes += chunk.length;
+            if(!this.push(chunk, 'ascii')) break;
+        }
+    }
+
+    /**
+     * @private
+     */
+    _endRead() {
+        if(!this._testReadStreamDestroy) this[kReadStream] = null;
+        this._isReading = false;
+        this._sendFileQueueSentCount++;
+        this._sendFileQueueReadDuration += Date.now() - this._readStartTime;
+        setImmediate(this._read.bind(this));
+    }
+
+    /**
+     *
+     * @param file
+     * @returns {Buffer}
+     * @private
+     */
+    _responseHeader(file) {
+        const resp = file.exists
+            ? Buffer.from(`+${file.type}${helpers.encodeInt64(file.size)}`, 'ascii')
+            : Buffer.from(`-${file.type}`, 'ascii');
+
+        return Buffer.concat([resp, file.guid, file.hash], resp.length + file.guid.length + file.hash.length);
+    }
+
+    /**
+     * @private
+     */
     _read() {
-        this._readReady = true;
-        Promise.resolve().then(() => this._read_internal());
+        // Continue file read in progress
+        if(this._isReading) {
+            this._readChunk();
+            return;
+        }
+
+        // No more files to send
+        if(this[kSendFileQueue].length === 0) {
+            return;
+        }
+
+        // De-queue the next file
+        const file = this[kSendFileQueue].shift();
+
+        if(!file.exists) {
+            this.push(this._responseHeader(file), 'ascii');
+            return;
+        }
+
+        // Set the _isReading flag outside of the async operation, in case _read is called
+        // again before the operation is complete.
+        this._isReading = true;
+
+        this[kCache].getFileStream(file.type, file.guid, file.hash)
+            .then(stream => {
+                this[kReadStream] = stream;
+                this._readStartTime = Date.now();
+                this.push(this._responseHeader(file), 'ascii');
+                this[kReadStream].on('readable', this._readChunk.bind(this));
+                this[kReadStream].once('end', this._endRead.bind(this));
+            }, err => {
+                helpers.log(consts.LOG_ERR, `Error reading file for GUID: ${helpers.GUIDBufferToString(file.guid)} Hash: ${file.hash.toString('hex')}`);
+                helpers.log(consts.LOG_ERR, err.message);
+                this._isReading = false;
+                file.exists = false;
+                this.push(this._responseHeader(file), 'ascii');
+            });
     }
 
     /**
@@ -102,73 +184,6 @@ class CommandProcessor extends Duplex {
      */
     _isWhitelisted(ip) {
         return this._whitelistEmpty || this._putWhitelist.includes(ip);
-    }
-
-    /**
-     * @private
-     */
-    async _read_internal() {
-        if(this._isReading || this[kSendFileQueue].length === 0)
-            return;
-        
-        const file = this[kSendFileQueue][0];
-        const resp = file.exists
-            ? Buffer.from(`+${file.type}${helpers.encodeInt64(file.size)}`, 'ascii')
-            : Buffer.from(`-${file.type}`, 'ascii');
-        const header = Buffer.concat([resp, file.guid, file.hash], resp.length + file.guid.length + file.hash.length);
-
-        this._readReady = this.push(header, 'ascii');
-
-        if(!file.exists) {
-            this[kSendFileQueue].shift();
-            return;
-        }
-
-        this._isReading = true;
-        this._readStartTime = Date.now();
-        let stream;
-
-        try {
-            stream = await this[kCache].getFileStream(file.type, file.guid, file.hash);
-            this[kReadStream] = stream;
-        }
-        catch(err) {
-            helpers.log(consts.LOG_ERR, err);
-            this._isReading = false;
-            return;
-        }
-
-        const readChunk = () => {
-            if(!this._readReady) {
-                return stream.destroyed || this[kSource] == null
-                    ? endRead()
-                    : setImmediate(readChunk);
-            }
-
-            let chunk;
-            while(chunk = stream.read()) {
-                this._readReady = this.push(chunk, 'ascii');
-                this._sendFileQueueChunkReads++;
-                this._sendFileQueueReadBytes += chunk.length;
-
-                if(!this._readReady) {
-                    setImmediate(readChunk);
-                    break;
-                }
-            }
-        };
-
-        const endRead = () => {
-            this[kReadStream] = null;
-            this[kSendFileQueue].shift();
-            this._sendFileQueueSentCount++;
-            this._isReading = false;
-            this._sendFileQueueReadDuration += Date.now() - this._readStartTime;
-            this._read();
-        };
-
-        stream.on('readable', readChunk);
-        stream.on('end', endRead);
     }
 
     /**
@@ -188,8 +203,7 @@ class CommandProcessor extends Duplex {
      * @private
      */
    async _quit(err) {
-       this[kSource].emit('quit');
-       this[kSource].unpipe(this);
+       if(this[kSource] !== null) this[kSource].emit('quit');
        this._writeHandler = this._writeHandlers.none;
        if(err) {
            helpers.log(consts.LOG_ERR, err.message);

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -51,6 +51,14 @@ class CacheServer {
 
     /**
      *
+     * @returns {net.Server}
+     */
+    get server() {
+        return this._server;
+    }
+
+    /**
+     *
      * @param {Function} cb
      */
     set errCallback(cb) {
@@ -69,6 +77,7 @@ class CacheServer {
             helpers.log(consts.LOG_TEST, `${socket.remoteAddress}:${socket.remotePort} connected.`);
 
             const cmdProc = new CommandProcessor(this.cache);
+            const streamProc = new ClientStreamProcessor({clientAddress: socket.remoteAddress});
 
             const mirrors = this._mirrors;
             if(mirrors.length > 0) {
@@ -82,13 +91,18 @@ class CacheServer {
 
             socket.on('close', () => {
                     helpers.log(consts.LOG_TEST, `${socket.remoteAddress}:${socket.remotePort} closed connection.`);
+                    socket.unpipe(streamProc);
+                    streamProc.unpipe(cmdProc);
+                    cmdProc.unpipe(socket);
                 }).on('error', err => {
                     helpers.log(consts.LOG_ERR, err);
                 });
 
-            socket.pipe(new ClientStreamProcessor({clientAddress: socket.remoteAddress})) // Transform the incoming byte stream into commands and file data
-                .pipe(cmdProc)                       // Execute commands and interface with the cache module
-                .pipe(socket);                       // Connect back to socket to send files
+            socket.pipe(streamProc) // Transform the incoming byte stream into commands and file data
+                .pipe(cmdProc)      // Execute commands and interface with the cache module
+                .pipe(socket);     // Connect back to socket to send files
+
+            socket['commandProcessor'] = cmdProc;
         });
 
         this._server.on('error', err => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "unity-cache-server",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/protocol.js
+++ b/test/protocol.js
@@ -231,15 +231,15 @@ describe("Protocol", () => {
 
                     client = await getClientPromise(server.port);
 
-                    // The Unity client always sends the version once on-connect. i.e., the version should not be pre-pended
-                    // to other request data in the tests below.
-                    clientWrite(client, helpers.encodeInt32(consts.PROTOCOL_VERSION));
-
-                    await new Promise(resolve => {
+                    return new Promise(resolve => {
                         server.server.once('connection', s => {
                             cmdProc = s.commandProcessor;
                             resolve();
                         });
+
+                        // The Unity client always sends the version once on-connect. i.e., the version should not be pre-pended
+                        // to other request data in the tests below.
+                        clientWrite(client, helpers.encodeInt32(consts.PROTOCOL_VERSION));
                     });
                 });
 

--- a/test/protocol.js
+++ b/test/protocol.js
@@ -239,7 +239,7 @@ describe("Protocol", () => {
 
                         // The Unity client always sends the version once on-connect. i.e., the version should not be pre-pended
                         // to other request data in the tests below.
-                        clientWrite(client, helpers.encodeInt32(consts.PROTOCOL_VERSION));
+                        client.write(helpers.encodeInt32(consts.PROTOCOL_VERSION));
                     });
                 });
 

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -74,7 +74,8 @@ exports.clientWrite = function(client, data, minPacketSize, maxPacketSize) {
     return new Promise((resolve, reject) => {
         let sentBytes = 0;
         let closed = false;
-        client.once('close', () => closed = true);
+        const closeListener = () => closed = true;
+        client.once('close', closeListener);
 
         if(typeof(minPacketSize) !== 'number') {
             minPacketSize = MIN_PACKET_SIZE;
@@ -98,6 +99,7 @@ exports.clientWrite = function(client, data, minPacketSize, maxPacketSize) {
                 sentBytes += len;
 
                 if (sentBytes === data.length) {
+                    client.removeListener('close', closeListener);
                     setTimeout(resolve, WRITE_RESOLVE_DELAY);
                 }
                 else {


### PR DESCRIPTION
This PR accomplishes a couple of things.
1) Implemented the necessary hooks for testing the read stream cleanup in a robust way. The previous test was flaky and also did not fully simulate a dropped connection using `client.destroy()`, which exposed some shortcomings in the implementation.
2) Rewrote the core file streaming code in `command_processor.js` to remove all of the inner loops (the main culprit in occasional 100% cpu usage), simplify design, improve error handling, and to increase clarity of intent. An additional test was added for the error case when a file is in the cache but a stream cannot be created for it.