### PR TITLE
bugfix/cli-config-fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Command                          | Description
 `-p`, `--port <n>`               | The port on which the Cache Server listens. The default value is 8126.
 `-c`, `--cache-module [path]`    | The path to cache module. The Default path is 'cache_fs'.
 `-P`, `--cache-path [path]`      | The path of the cache directory.
-`-l`, `--log-level <n>`          | The level of log verbosity. Valid values are 0 (silent) through 5 (debug). The default is 3.
+`-l`, `--log-level <n>`          | The level of log verbosity. Valid values are 0 (silent) through 5 (debug). The default is 3 (info).
 `-w`, `--workers <n>`            | The number of worker threads to spawn. The default is 0.
 `-m`, `--mirror <host:port>`     | Mirror transactions to another cache server. Repeat this option for multiple mirrors.
-`-W`, `--putwhitelist <host:port>`  | Only allow PUT transactions (uploads) from the specified client address. Can be repeated for multiple clients
+`-W`, `--putwhitelist <host:port>`  | Only allow PUT transactions (uploads) from the specified client address. Repeat this option for multiple addresses.
 `--dump-config`                  | Write the active configuration to the console.
 `--save-config [path]`           | Write the active configuration to the specified file and exit. Defaults to `./default.yml`.
 `--NODE_CONFIG_DIR=<path>`       | The directory to search for config files. This is equivalent to setting the `NODE_CONFIG_DIR` environment variable. If not specified, the built-in configuration is used.

--- a/cleanup.js
+++ b/cleanup.js
@@ -37,8 +37,7 @@ const optionMap = {
     maxCacheSize: {
         flags: "-s, --max-cache-size <bytes>",
         description: "Override the configured maximum cache size. Files will be removed from the cache until the max cache size is satisfied, using a Least Recently Used search. A value of 0 disables this check.",
-        validator: parseInt,
-        default: 0
+        validator: parseInt
     },
     delete: {
         flags: "-d, --delete",

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -14,6 +14,8 @@ const constants = {
     LOG_DBG: 5,
     DEFAULT_PORT: 8126,
     DEFAULT_WORKERS: 0,
+    DEFAULT_CACHE_MODULE: 'cache_fs',
+    DEFAULT_CACHE_PATH: '.unity_cache',
     FILE_TYPE: {
         INFO: 'i',
         BIN: 'a',
@@ -27,6 +29,7 @@ const constants = {
         PORT: "Server.port",
         MIRROR: "Mirror.addresses",
         ALLOW_IP_V6: "Server.options.allowIpv6",
+        COMMAND_PROCESSOR: "Cache.options.processor",
         PUTWHITELIST: "Cache.options.processor.putWhitelist"
     }
 };

--- a/lib/server/command_processor.js
+++ b/lib/server/command_processor.js
@@ -37,9 +37,17 @@ class CommandProcessor extends Duplex {
          */
         this._trx = null;
 
-        this._options = require('config').get("Cache.options.processor");
-        this._putWhitelist = this._options.putWhitelist;
-        this._whitelistEmpty = (!Array.isArray(this._putWhitelist) || !this._putWhitelist.length);
+        const config = require('config');
+        this._options = [];
+        if(config.has(consts.CLI_CONFIG_KEYS.COMMAND_PROCESSOR)) {
+            this._options = config.get(consts.CLI_CONFIG_KEYS.COMMAND_PROCESSOR);
+        }
+
+        this._putWhitelist = [];
+        if(config.has(consts.CLI_CONFIG_KEYS.PUTWHITELIST)) {
+            this._putWhitelist = this._options.putWhitelist;
+            this._whitelistEmpty = (!Array.isArray(this._putWhitelist) || !this._putWhitelist.length);
+        }
 
         if(!this._whitelistEmpty) {
             helpers.log(consts.LOG_INFO, `PUT whitelist: ${this._putWhitelist}`);

--- a/lib/unity_cache_server.js
+++ b/lib/unity_cache_server.js
@@ -8,6 +8,11 @@ const path = require('path');
 const fs = require('fs-extra');
 
 class UnityCacheServer {
+    static getConfigVal(key, defVal) {
+        const config = require('config');
+        return config.has(key) ? config.get(key) : defVal;
+    };
+
     static dumpConfig() {
         const configData = yaml.safeDump(require('config'));
         helpers.log(0, configData);
@@ -31,9 +36,8 @@ class UnityCacheServer {
     }
 
     static async getMirrors() {
-        const config = require('config');
-        const mirror = config.get(consts.CLI_CONFIG_KEYS.MIRROR);
-        const myPort = config.get(consts.CLI_CONFIG_KEYS.PORT);
+        const mirror = this.getConfigVal(consts.CLI_CONFIG_KEYS.MIRROR, []);
+        const myPort = this.getConfigVal(consts.CLI_CONFIG_KEYS.PORT, consts.DEFAULT_PORT);
         const myIp = ip.address();
 
         const mirrors = mirror.map(async m => {
@@ -62,9 +66,8 @@ class UnityCacheServer {
                 description: "Write the active configuration to the console"
             },
             saveConfig: {
-                flags: "--save-config [path]",
-                description: "Write the active configuration to the specified file and exit",
-                defaultValue: "default.yml"
+                flags: "--save-config <path>",
+                description: "Write the active configuration to the specified file and exit"
             },
             nodeConfigDir: {
                 flags: "--NODE_CONFIG_DIR=<path>",
@@ -74,8 +77,8 @@ class UnityCacheServer {
 
         // Add CLI options
         for(const o of _.values(optionMap)) {
-            const validator = o.hasOwnProperty('validator') ? o.validator : null;
-            const defaultValue = o.hasOwnProperty('defaultValue') ? o.defaultValue : null;
+            const validator = o.hasOwnProperty('validator') ? o.validator : undefined;
+            const defaultValue = o.hasOwnProperty('defaultValue') ? o.defaultValue : undefined;
             cmd.option(o.flags, o.description, validator, defaultValue);
         }
 
@@ -92,13 +95,8 @@ class UnityCacheServer {
 
         process.env.NODE_CONFIG = JSON.stringify(overrides);
 
-        // Load config
-        const config = require('config');
-
         // Init logging
-        const logLevel = config.has(consts.CLI_CONFIG_KEYS.LOG_LEVEL)
-            ? config.get(consts.CLI_CONFIG_KEYS.LOG_LEVEL)
-            : consts.DEFAULT_LOG_LEVEL;
+        const logLevel = this.getConfigVal(consts.CLI_CONFIG_KEYS.LOG_LEVEL, consts.DEFAULT_LOG_LEVEL);
 
         helpers.setLogLevel(logLevel);
 
@@ -125,16 +123,13 @@ class UnityCacheServer {
             return this.constructor._cache_instance;
         }
 
-        const config = require('config');
-
         // Find and load the desired cache module
-        const cacheModuleName = config.get(consts.CLI_CONFIG_KEYS.CACHE_MODULE);
+        const cacheModuleName = this.getConfigVal(consts.CLI_CONFIG_KEYS.CACHE_MODULE, consts.DEFAULT_CACHE_MODULE);
         const CacheModule = helpers.resolveCacheModule(cacheModuleName, path.resolve(__dirname, 'cache'));
 
         const myOpts = Object.assign({}, opts);
-        myOpts.cachePath = config.has(consts.CLI_CONFIG_KEYS.CACHE_PATH)
-            ? config.get(consts.CLI_CONFIG_KEYS.CACHE_PATH)
-            : config.get(`Cache.options.${cacheModuleName}.cachePath`);
+        myOpts.cachePath = this.getConfigVal(consts.CLI_CONFIG_KEYS.CACHE_PATH,
+            this.getConfigVal(`Cache.options.${cacheModuleName}.cachePath`, consts.DEFAULT_CACHE_PATH));
 
         this.constructor._cache_instance = new CacheModule();
         this.constructor._cache_module_name = cacheModuleName;
@@ -147,19 +142,14 @@ class UnityCacheServer {
      * @returns {Promise<Server>}
      */
     static async start() {
-        const config = require('config');
         const consts = require('./constants');
         const cluster = require('cluster');
         const Server = require('./server/server');
 
-        const getConfigVal = (key, defVal) => {
-            return config.has(key) ? config.get(key) : defVal;
-        };
-
         const cache = await UnityCacheServer.initCache();
 
         // Define # of worker threads
-        let workers = getConfigVal(consts.CLI_CONFIG_KEYS.WORKERS, 0);
+        let workers = this.getConfigVal(consts.CLI_CONFIG_KEYS.WORKERS, 0);
         if(workers > 0 && !cache.constructor.properties.clustering) {
             workers = 0;
             helpers.log(consts.LOG_INFO, `Clustering disabled, current cache module ${this.constructor._cache_module_name} does not support it.`);
@@ -168,9 +158,9 @@ class UnityCacheServer {
         helpers.setLogger(workers > 0 ? helpers.defaultClusterLogger : helpers.defaultLogger);
 
         const serverOpts = {
-            port: getConfigVal(consts.CLI_CONFIG_KEYS.PORT, consts.DEFAULT_PORT),
+            port: this.getConfigVal(consts.CLI_CONFIG_KEYS.PORT, consts.DEFAULT_PORT),
             mirror: await this.getMirrors(),
-            allowIpv6: getConfigVal(consts.CLI_CONFIG_KEYS.ALLOW_IP_V6, false)
+            allowIpv6: this.getConfigVal(consts.CLI_CONFIG_KEYS.ALLOW_IP_V6, false)
         };
 
         // create Server

--- a/lib/unity_cache_server.js
+++ b/lib/unity_cache_server.js
@@ -57,17 +57,17 @@ class UnityCacheServer {
         _.defaultsDeep(optionMap, {
             logLevel: {
                 flags: "-l, --log-level <n>",
-                description: "Specify the level of log verbosity. Valid values are 0 (silent) through 5 (debug)",
+                description: "The level of log verbosity. Valid values are 0 (silent) through 5 (debug). The default is 3 (info).",
                 validator: parseInt,
                 configKey: consts.CLI_CONFIG_KEYS.LOG_LEVEL
             },
             dumpConfig: {
                 flags: "--dump-config",
-                description: "Write the active configuration to the console"
+                description: "Write the active configuration to the console."
             },
             saveConfig: {
-                flags: "--save-config <path>",
-                description: "Write the active configuration to the specified file and exit"
+                flags: "--save-config [path]",
+                description: "Write the active configuration to the specified file and exit. Defaults to `./default.yml`."
             },
             nodeConfigDir: {
                 flags: "--NODE_CONFIG_DIR=<path>",

--- a/lib/unity_cache_server.js
+++ b/lib/unity_cache_server.js
@@ -76,12 +76,9 @@ class UnityCacheServer {
         });
 
         // Add CLI options
-        for(const o of _.values(optionMap)) {
-            const validator = o.hasOwnProperty('validator') ? o.validator : undefined;
-            const defaultValue = o.hasOwnProperty('defaultValue') ? o.defaultValue : undefined;
-            cmd.option(o.flags, o.description, validator, defaultValue);
-        }
+        _.values(optionMap).forEach(o => cmd.option(o.flags, o.description, o.validator, o.defaultValue));
 
+        // Parse shell args
         cmd.parse(argv);
 
         // Set CLI config overrides

--- a/main.js
+++ b/main.js
@@ -18,35 +18,35 @@ function collect(val, memo) {
 const optionMap = {
     cacheModule: {
         flags: "-c --cache-module <path>",
-        description: "Use cache module at specified path",
+        description: "The path to cache module. The Default path is 'cache_fs'.",
         configKey: consts.CLI_CONFIG_KEYS.CACHE_MODULE
     },
     cachePath: {
         flags: "-P, --cache-path <path>",
-        description: "Specify the path of the cache directory",
+        description: "The path of the cache directory.",
         configKey: consts.CLI_CONFIG_KEYS.CACHE_PATH
     },
     port: {
         flags: "-p, --port <n>",
-        description: "Specify the server port",
+        description: "The port on which the Cache Server listens. The default value is 8126.",
         validator: parseInt,
         configKey: consts.CLI_CONFIG_KEYS.PORT
     },
     workers: {
         flags: "-w, --workers <n>",
-        description: "Number of worker threads to spawn",
+        description: "The number of worker threads to spawn. The default is 0.",
         validator: zeroOrMore,
         configKey: consts.CLI_CONFIG_KEYS.WORKERS
     },
     mirror: {
         flags: "-m --mirror <host:port>",
-        description: "Mirror transactions to another cache server. Can be repeated for multiple mirrors",
+        description: "Mirror transactions to another cache server. Repeat this option for multiple mirrors.",
         validator: collect,
         configKey: consts.CLI_CONFIG_KEYS.MIRROR
     },
     putwhitelist: {
         flags: "-W --putwhitelist <host:port>",
-        description: "Only allow PUT transactions (uploads) from the specified client address. Can be repeated for multiple clients",
+        description: "Only allow PUT transactions (uploads) from the specified client address. Repeat this option for multiple addresses.",
         validator: collect,
         configKey: consts.CLI_CONFIG_KEYS.PUTWHITELIST
     }

--- a/main.js
+++ b/main.js
@@ -10,6 +10,7 @@ function zeroOrMore(val) {
 }
 
 function collect(val, memo) {
+    memo = memo || [];
     memo.push(val);
     return memo;
 }
@@ -27,7 +28,7 @@ const optionMap = {
     },
     port: {
         flags: "-p, --port <n>",
-        description: "Specify the server port, only apply to new cache server",
+        description: "Specify the server port",
         validator: parseInt,
         configKey: consts.CLI_CONFIG_KEYS.PORT
     },
@@ -41,14 +42,12 @@ const optionMap = {
         flags: "-m --mirror <host:port>",
         description: "Mirror transactions to another cache server. Can be repeated for multiple mirrors",
         validator: collect,
-        defaultValue: [],
         configKey: consts.CLI_CONFIG_KEYS.MIRROR
     },
     putwhitelist: {
         flags: "-W --putwhitelist <host:port>",
         description: "Only allow PUT transactions (uploads) from the specified client address. Can be repeated for multiple clients",
         validator: collect,
-        defaultValue: [],
         configKey: consts.CLI_CONFIG_KEYS.PUTWHITELIST
     }
 };


### PR DESCRIPTION
- Ensure all config values fallback to a default (#86)
- Remove most CLI default values, as they will supersede config file values, which is not the expected behavior.
- Fix CLI help output to not display `(default: null)` for every option