### PR TITLE
Fix issue #103, reliability manager not differentiating clients behind a NAT

### DIFF
--- a/lib/server/command_processor.js
+++ b/lib/server/command_processor.js
@@ -193,7 +193,9 @@ class CommandProcessor extends Duplex {
      * @private
      */
     _isWhitelisted(ip) {
-        return this._whitelistEmpty || this._putWhitelist.includes(ip);
+        if(this._whitelistEmpty) return true;
+        const [address] = ip.split(':');
+        return this._putWhitelist.includes(address);
     }
 
     /**
@@ -383,9 +385,7 @@ class CommandProcessor extends Duplex {
             throw new Error("Not in a transaction");
         }
 
-        const [host] = this._trx.clientAddress.split(':');
-
-        if (this._isWhitelisted(host)) {
+        if (this._isWhitelisted(this._trx.clientAddress)) {
             this._putStream = await this._trx.getWriteStream(type, size);
         } else {
             this._putStream = new Writable({
@@ -393,6 +393,7 @@ class CommandProcessor extends Duplex {
                     setImmediate(cb);
                 }
             });
+
             helpers.log(consts.LOG_DBG, `PUT rejected from non-whitelisted IP: ${this._trx.clientAddress}`);
         }
 

--- a/lib/server/command_processor.js
+++ b/lib/server/command_processor.js
@@ -383,7 +383,9 @@ class CommandProcessor extends Duplex {
             throw new Error("Not in a transaction");
         }
 
-        if (this._isWhitelisted(this._trx.clientAddress)) {
+        const [host] = this._trx.clientAddress.split(':');
+
+        if (this._isWhitelisted(host)) {
             this._putStream = await this._trx.getWriteStream(type, size);
         } else {
             this._putStream = new Writable({

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -77,7 +77,7 @@ class CacheServer {
             helpers.log(consts.LOG_TEST, `${socket.remoteAddress}:${socket.remotePort} connected.`);
 
             const cmdProc = new CommandProcessor(this.cache);
-            const streamProc = new ClientStreamProcessor({clientAddress: socket.remoteAddress});
+            const streamProc = new ClientStreamProcessor({clientAddress: `${socket.remoteAddress}:${socket.remotePort}`});
 
             const mirrors = this._mirrors;
             if(mirrors.length > 0) {

--- a/test/command_processor.js
+++ b/test/command_processor.js
@@ -15,7 +15,7 @@ describe("CommandProcessor", () => {
             this.cmdProc._putWhitelist = ["127.0.0.1"];
 
             this.cmdProc._trx = new PutTransaction();
-            this.cmdProc._trx.clientAddress = "127.0.0.1";
+            this.cmdProc._trx.clientAddress = "127.0.0.1:1234";
             const spy = sinon.spy(this.cmdProc._trx, "getWriteStream");
 
             const p = this.cmdProc._onPut("a", 999);
@@ -29,7 +29,7 @@ describe("CommandProcessor", () => {
             this.cmdProc._putWhitelist = ["127.0.0.6", "127.0.0.3", "127.0.0.1"];
 
             this.cmdProc._trx = new PutTransaction();
-            this.cmdProc._trx.clientAddress = "127.0.0.1";
+            this.cmdProc._trx.clientAddress = "127.0.0.1:1234";
             const spy = sinon.spy(this.cmdProc._trx, "getWriteStream");
 
             const p = this.cmdProc._onPut("a", 999);
@@ -43,7 +43,7 @@ describe("CommandProcessor", () => {
             this.cmdProc._putWhitelist = [];
 
             this.cmdProc._trx = new PutTransaction();
-            this.cmdProc._trx.clientAddress = "127.0.0.1";
+            this.cmdProc._trx.clientAddress = "127.0.0.1:1234";
             const spy = sinon.spy(this.cmdProc._trx, "getWriteStream");
 
             const p = this.cmdProc._onPut("a", 999);
@@ -57,7 +57,7 @@ describe("CommandProcessor", () => {
             this.cmdProc._putWhitelist = ["127.0.0.1"];
 
             this.cmdProc._trx = new PutTransaction();
-            this.cmdProc._trx.clientAddress = "127.0.0.2";
+            this.cmdProc._trx.clientAddress = "127.0.0.2:1234";
 
             await this.cmdProc._onPut("a", 6);
             assert.strictEqual(this.cmdProc._writeHandler, this.cmdProc._writeHandlers.putStream);

--- a/test/reliability_manager.js
+++ b/test/reliability_manager.js
@@ -157,17 +157,34 @@ describe("ReliabilityManager", () => {
                 const hash = randomBuffer(consts.HASH_SIZE);
 
                 const trx = new StablePutTransaction(guid, hash);
-                trx.clientAddress = "A";
+                trx.clientAddress = "A:1234";
                 await myRm.processTransaction(trx);
 
                 const entry = rm.getEntry(helpers.GUIDBufferToString(trx.guid), trx.hash.toString('hex'));
                 assert.equal(entry.state, ReliabilityManager.reliabilityStates.Pending);
 
-                trx.clientAddress = "A";
+                trx.clientAddress = "A:1234";
                 await myRm.processTransaction(trx);
                 assert.equal(entry.state, ReliabilityManager.reliabilityStates.Pending);
 
-                trx.clientAddress = "B";
+                trx.clientAddress = "B:1234";
+                await myRm.processTransaction(trx);
+                assert.equal(entry.state, ReliabilityManager.reliabilityStates.ReliableNew);
+            });
+
+            it("should increment the reliability factor for the same IP on different ports", async () => {
+                const myRm = new ReliabilityManager(db, tmp.tmpNameSync(), { reliabilityThreshold: 2, multiClient: true });
+                const guid = randomBuffer(consts.GUID_SIZE);
+                const hash = randomBuffer(consts.HASH_SIZE);
+
+                const trx = new StablePutTransaction(guid, hash);
+                trx.clientAddress = "A:1234";
+                await myRm.processTransaction(trx);
+
+                const entry = rm.getEntry(helpers.GUIDBufferToString(trx.guid), trx.hash.toString('hex'));
+                assert.equal(entry.state, ReliabilityManager.reliabilityStates.Pending);
+
+                trx.clientAddress = "A:4321";
                 await myRm.processTransaction(trx);
                 assert.equal(entry.state, ReliabilityManager.reliabilityStates.ReliableNew);
             });


### PR DESCRIPTION
include the remote port in the client ID for the ReliabilityManager, so clients behind the same NAT will be recognized as unique.