### PR TITLE
Improve test coverage

### DIFF
--- a/lib/cache/cache_base.js
+++ b/lib/cache/cache_base.js
@@ -10,6 +10,7 @@ const { promisify } = require('util');
 const loki = require('lokijs');
 const ReliabilityManager = require('./reliability_manager');
 const _ = require('lodash');
+const { Writable } = require('stream');
 
 const kDbName = 'cache.db';
 
@@ -176,7 +177,7 @@ class CacheBase extends EventEmitter {
      * @returns {Promise<any>}
      */
     createPutTransaction(guid, hash) {
-        return Promise.reject(new Error("Not implemented"));
+        return Promise.resolve(new PutTransaction(guid, hash));
     }
 
     /**
@@ -300,7 +301,9 @@ class PutTransaction extends EventEmitter {
      * @returns {Promise<any>}
      */
     getWriteStream(type, size) {
-        return Promise.reject(new Error("Not implemented"));
+        return Promise.resolve(new Writable({
+            write(chunk, encoding, cb){ setImmediate(cb); }
+        }));
     }
 
     async invalidate() {
@@ -313,7 +316,7 @@ class PutTransaction extends EventEmitter {
      * @returns {Promise<any>}
      */
     async writeFilesToPath(targetPath) {
-        return Promise.reject(new Error("Not implemented"));
+        return Promise.resolve();
     }
 }
 

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -20,8 +20,12 @@ class CacheServer {
             this._port = consts.DEFAULT_PORT;
 
         this._server = null;
-        this._mirrorConfig = options.mirror ? [].concat(options.mirror) : [];
         this._mirrors = [];
+
+        if(options.mirror) {
+            options.mirror = [].concat(options.mirror);
+            this._mirrors = options.mirror.map(m => new TransactionMirror(m, cache));
+        }
 
         this.allowIpv6 = options.allowIpv6;
         this._errCallback = null;
@@ -83,11 +87,10 @@ class CacheServer {
             const cmdProc = new CommandProcessor(this.cache);
             const streamProc = new ClientStreamProcessor({clientAddress: `${socket.remoteAddress}:${socket.remotePort}`});
 
-            if(this._mirrors.length > 0) {
+            const mirrors = this._mirrors;
+            if(mirrors.length > 0) {
                 cmdProc.on('onTransactionEnd', (trx) => {
-                    this._mirrors.forEach(m => {
-                        m.queueTransaction(trx);
-                    });
+                    mirrors.forEach(m => m.queueTransaction(trx));
                 });
             }
 
@@ -111,10 +114,6 @@ class CacheServer {
             }
 
             if (this._errCallback && typeof(this._errCallback === 'function')) { this._errCallback(err); }
-        }).on('listening', () => {
-            this._mirrors = this._mirrorConfig
-                .filter(m => m && m.port && m.host)
-                .map(m => new TransactionMirror(m, this.cache));
         });
 
         return new Promise(resolve => {

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -20,12 +20,8 @@ class CacheServer {
             this._port = consts.DEFAULT_PORT;
 
         this._server = null;
+        this._mirrorConfig = options.mirror ? [].concat(options.mirror) : [];
         this._mirrors = [];
-
-        if(options.mirror) {
-            options.mirror = [].concat(options.mirror);
-            this._mirrors = options.mirror.map(m => new TransactionMirror(m, cache));
-        }
 
         this.allowIpv6 = options.allowIpv6;
         this._errCallback = null;
@@ -59,6 +55,14 @@ class CacheServer {
 
     /**
      *
+     * @returns {Array|*}
+     */
+    get mirrors() {
+        return this._mirrors;
+    }
+
+    /**
+     *
      * @param {Function} cb
      */
     set errCallback(cb) {
@@ -79,12 +83,10 @@ class CacheServer {
             const cmdProc = new CommandProcessor(this.cache);
             const streamProc = new ClientStreamProcessor({clientAddress: `${socket.remoteAddress}:${socket.remotePort}`});
 
-            const mirrors = this._mirrors;
-            if(mirrors.length > 0) {
+            if(this._mirrors.length > 0) {
                 cmdProc.on('onTransactionEnd', (trx) => {
-                    mirrors.forEach(m => {
-                        if(m.address !== socket.remoteAddress)
-                            m.queueTransaction(trx);
+                    this._mirrors.forEach(m => {
+                        m.queueTransaction(trx);
                     });
                 });
             }
@@ -103,14 +105,16 @@ class CacheServer {
                 .pipe(socket);     // Connect back to socket to send files
 
             socket['commandProcessor'] = cmdProc;
-        });
-
-        this._server.on('error', err => {
+        }).on('error', err => {
             if (err.code === 'EADDRINUSE') {
                 helpers.log(consts.LOG_ERR, `Port ${this.port} is already in use...`);
             }
 
             if (this._errCallback && typeof(this._errCallback === 'function')) { this._errCallback(err); }
+        }).on('listening', () => {
+            this._mirrors = this._mirrorConfig
+                .filter(m => m && m.port && m.host)
+                .map(m => new TransactionMirror(m, this.cache));
         });
 
         return new Promise(resolve => {

--- a/lib/server/transaction_mirror.js
+++ b/lib/server/transaction_mirror.js
@@ -37,6 +37,10 @@ class TransactionMirror {
         return this._connectOptions.host;
     }
 
+    get port() {
+        return this._connectOptions.port;
+    }
+
     _connect() {
         helpers.log(consts.LOG_INFO, `[TransactionMirror] Connecting to ${this._connectOptions.host}:${this._connectOptions.port}`);
         return this._client.connect();

--- a/test/cache_base.js
+++ b/test/cache_base.js
@@ -8,6 +8,7 @@ const path = require('path');
 const randomBuffer = require('./test_utils').randomBuffer;
 const consts = require('../lib/constants');
 const sinon = require('sinon');
+const { Writable } = require('stream');
 
 describe("Cache: Base Class", () => {
     let cache;
@@ -124,9 +125,9 @@ describe("Cache: Base Class", () => {
     });
 
     describe("createPutTransaction", () => {
-        it("should require override implementation in subclasses by returning an error", () => {
-            return cache.createPutTransaction()
-                .then(() => { throw new Error("Expected error!"); }, () => {});
+        it("should return an instance of a PutTransaction", async () => {
+            const t = await cache.createPutTransaction();
+            assert.ok(t instanceof PutTransaction);
         });
     });
 
@@ -264,16 +265,16 @@ describe("PutTransaction: Base Class", () => {
     });
 
     describe("getWriteStream", () => {
-        it("should require override implementation in subclasses by returning an error", () => {
-            return trx.getWriteStream(consts.FILE_TYPE.INFO, 0)
-                .then(() => { throw new Error("Expected error!"); }, () => {});
+        it("should return a Writable stream", async() => {
+            const s = await trx.getWriteStream(consts.FILE_TYPE.INFO, 0);
+            assert.ok(s instanceof Writable);
         });
     });
 
     describe("writeFilesToPath", () => {
-        it("should require override implementation in subclasses by returning an error", () => {
-            return trx.writeFilesToPath()
-                .then(() => { throw new Error("Expected error!"); }, () => {});
+        it("should return a promise", () => {
+            const p = trx.writeFilesToPath();
+            assert.ok(p instanceof Promise);
         });
     });
 });

--- a/test/protocol.js
+++ b/test/protocol.js
@@ -323,6 +323,7 @@ describe("Protocol", () => {
                 });
 
                 const tests = [
+                    {cmd: cmd.getAsset, blob: self.data.bin, type: 'bin', packetSize: 1},
                     {cmd: cmd.getAsset, blob: self.data.bin, type: 'bin', packetSize: SMALL_PACKET_SIZE},
                     {cmd: cmd.getInfo, blob: self.data.info, type: 'info', packetSize: MED_PACKET_SIZE},
                     {cmd: cmd.getResource, blob: self.data.resource, type: 'resource', packetSize: LARGE_PACKET_SIZE}

--- a/test/unity_cache_server.js
+++ b/test/unity_cache_server.js
@@ -208,6 +208,9 @@ describe("Unity Cache Server bootstrap", () => {
                             cachePath: tmpPath
                         }
                     }
+                },
+                Server: {
+                    port: 0
                 }
             });
 


### PR DESCRIPTION
- Add test coverage for transaction mirroring. In the process, I simplified the implementation to remove a check that was intended to prevent looping transactions but in practice would only be effective in limited cases, and would actually prevent mirrors running on different ports behind the same NAT address from replicating.

- Add another protocol test case to catch all of the branches in client_stream_processor