### PR TITLE
[pr] optimize download queue

### DIFF
--- a/lib/server/command_processor.js
+++ b/lib/server/command_processor.js
@@ -60,7 +60,7 @@ class CommandProcessor extends Duplex {
         this._sendFileQueueReadDuration = 0;
         this._sendFileQueueReadBytes = 0;
         this._sendFileQueueCount = 0;
-        this._sendFileQueueSentCount = 0;
+        this._sendFileQueueIndex = 0;
         this._isReading = false;
         this._testReadStreamDestroy = false;
         this._registerEventListeners();
@@ -128,7 +128,6 @@ class CommandProcessor extends Duplex {
         // during a file read. This ensures the `destroy()` logic during the unpipe event handler is called on the open stream.
         if(!this._testReadStreamDestroy) this[kReadStream] = null;
         this._isReading = false;
-        this._sendFileQueueSentCount++;
         this._sendFileQueueReadDuration += Date.now() - this._readStartTime;
         setImmediate(this._read.bind(this));
     }
@@ -157,12 +156,15 @@ class CommandProcessor extends Duplex {
         }
 
         // No more files to send
-        if(this[kSendFileQueue].length === 0) {
+        const qLen = this[kSendFileQueue].length;
+        if(qLen === 0 || this._sendFileQueueIndex >= qLen) {
             return;
         }
 
         // De-queue the next file
-        const file = this[kSendFileQueue].shift();
+        const file = this[kSendFileQueue][this._sendFileQueueIndex];
+        delete this[kSendFileQueue][this._sendFileQueueIndex];
+        this._sendFileQueueIndex++;
 
         // Respond with file-not-found header and early out, wait for next _read
         if(!file.exists) {
@@ -206,7 +208,7 @@ class CommandProcessor extends Duplex {
         if(this._sendFileQueueReadDuration > 0) {
             const totalTime = this._sendFileQueueReadDuration / 1000;
             const throughput = (this._sendFileQueueReadBytes / totalTime).toFixed(2);
-            helpers.log(consts.LOG_INFO, `Sent ${this._sendFileQueueSentCount} of ${this._sendFileQueueCount} requested files (${this._sendFileQueueChunkReads} chunks) totaling ${filesize(this._sendFileQueueReadBytes)} in ${totalTime} seconds (${filesize(throughput)}/sec) to ${this[kSource].clientAddress}`);
+            helpers.log(consts.LOG_INFO, `Sent ${this._sendFileQueueIndex} of ${this._sendFileQueueCount} requested files (${this._sendFileQueueChunkReads} chunks) totaling ${filesize(this._sendFileQueueReadBytes)} in ${totalTime} seconds (${filesize(throughput)}/sec) to ${this[kSource].clientAddress}`);
         }
     }
 


### PR DESCRIPTION
Remove use of array shift() to process the download queue, in favor of incrementing an index pointer. This is far faster and more memory efficient, especially when the requests scale into the tens of thousands.