### PR TITLE
[pr] Fixes for issue #118

### DIFF
--- a/lib/cache/cache_base.js
+++ b/lib/cache/cache_base.js
@@ -188,7 +188,7 @@ class CacheBase extends EventEmitter {
     async endPutTransaction(transaction) {
         await transaction.finalize();
 
-        if(this._rm !== null && this._options.highReliability && transaction.isValid)
+        if(this._rm !== null && this._options.highReliability)
             return this._rm.processTransaction(transaction);
     }
 

--- a/lib/cache/reliability_manager.js
+++ b/lib/cache/reliability_manager.js
@@ -97,7 +97,7 @@ class ReliabilityManager {
      * @returns {Promise<void>}
      */
     async processTransaction(trx) {
-        if(!trx.isValid) return Promise.resolve();
+        if(!trx.isValid) return;
 
         const params = {
             guidStr: helpers.GUIDBufferToString(trx.guid),

--- a/lib/cache/reliability_manager.js
+++ b/lib/cache/reliability_manager.js
@@ -97,6 +97,8 @@ class ReliabilityManager {
      * @returns {Promise<void>}
      */
     async processTransaction(trx) {
+        if(!trx.isValid) return Promise.resolve();
+
         const params = {
             guidStr: helpers.GUIDBufferToString(trx.guid),
             hashStr: trx.hash.toString('hex'),

--- a/lib/server/command_processor.js
+++ b/lib/server/command_processor.js
@@ -74,6 +74,14 @@ class CommandProcessor extends Duplex {
         return this[kReadStream];
     }
 
+    /**
+     *
+     * @returns {*|String}
+     */
+    get clientAddress() {
+        return this[kSource].clientAddress;
+    }
+
     _registerEventListeners() {
         this.once('finish', this._printReadStats);
         this.on('pipe', src => {
@@ -208,7 +216,7 @@ class CommandProcessor extends Duplex {
         if(this._sendFileQueueReadDuration > 0) {
             const totalTime = this._sendFileQueueReadDuration / 1000;
             const throughput = (this._sendFileQueueReadBytes / totalTime).toFixed(2);
-            helpers.log(consts.LOG_INFO, `Sent ${this._sendFileQueueIndex} of ${this._sendFileQueueCount} requested files (${this._sendFileQueueChunkReads} chunks) totaling ${filesize(this._sendFileQueueReadBytes)} in ${totalTime} seconds (${filesize(throughput)}/sec) to ${this[kSource].clientAddress}`);
+            helpers.log(consts.LOG_INFO, `Sent ${this._sendFileQueueIndex} of ${this._sendFileQueueCount} requested files (${this._sendFileQueueChunkReads} chunks) totaling ${filesize(this._sendFileQueueReadBytes)} in ${totalTime} seconds (${filesize(throughput)}/sec) to ${this.clientAddress}`);
         }
     }
 
@@ -356,8 +364,14 @@ class CommandProcessor extends Duplex {
         }
 
         this._trx = await this[kCache].createPutTransaction(guid, hash);
-        this._trx.clientAddress = this[kSource].clientAddress;
+        this._trx.clientAddress = this.clientAddress;
+
         helpers.log(consts.LOG_DBG, `Start transaction for GUID: ${helpers.GUIDBufferToString(guid)} Hash: ${hash.toString('hex')}`);
+
+        if(!this._isWhitelisted(this._trx.clientAddress)) {
+            await this._trx.invalidate();
+            helpers.log(consts.LOG_DBG, `Transaction invalidated from non-whitelisted IP: ${this._trx.clientAddress}`);
+        }
     }
 
     /**
@@ -388,7 +402,7 @@ class CommandProcessor extends Duplex {
             throw new Error("Not in a transaction");
         }
 
-        if (this._isWhitelisted(this._trx.clientAddress)) {
+        if (this._trx.isValid) {
             this._putStream = await this._trx.getWriteStream(type, size);
         } else {
             this._putStream = new Writable({
@@ -396,8 +410,6 @@ class CommandProcessor extends Duplex {
                     setImmediate(cb);
                 }
             });
-
-            helpers.log(consts.LOG_DBG, `PUT rejected from non-whitelisted IP: ${this._trx.clientAddress}`);
         }
 
         this._putStream.promiseWrite = promisify(this._putStream.write).bind(this._putStream);

--- a/lib/server/command_processor.js
+++ b/lib/server/command_processor.js
@@ -63,6 +63,7 @@ class CommandProcessor extends Duplex {
         this._sendFileQueueIndex = 0;
         this._isReading = false;
         this._testReadStreamDestroy = false;
+        this._clientAddress = "(unknown)";
         this._registerEventListeners();
     }
 
@@ -79,13 +80,14 @@ class CommandProcessor extends Duplex {
      * @returns {*|String}
      */
     get clientAddress() {
-        return this[kSource].clientAddress;
+        return this._clientAddress;
     }
 
     _registerEventListeners() {
         this.once('finish', this._printReadStats);
         this.on('pipe', src => {
             this[kSource] = src;
+            this._clientAddress = src.clientAddress;
         });
 
         this.on('unpipe', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,27 +129,28 @@
       }
     },
     "@sinonjs/commons": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
-      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
     },
     "@sinonjs/formatio": {
-      "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.1.1.tgz",
-      "integrity": "sha512-ILlwvQUwAiaVBzr3qz8oT1moM7AIUHqUc2UmEjQcH9lLe+E+BZPwUMuc9FFojMswRK4r96x5zDTTrowMLw/vuA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
+      "integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.0.2",
@@ -723,9 +724,9 @@
       "dev": true
     },
     "diff": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "ecc-jsbn": {
@@ -1644,12 +1645,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
-    },
     "log-driver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
@@ -1670,9 +1665,9 @@
       "integrity": "sha1-HCH4KvdXkDf63nueSBNIXCNwi7Y="
     },
     "lolex": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.4.1.tgz",
-      "integrity": "sha512-8QdNQMqlAE2kkc2YWR3Ld0evgE452mmyYZR4HTh54PeH8UAjDipHYh/FHq6y9cAvM68nxGxj5jAz97+WQ2AQEQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.0.1.tgz",
+      "integrity": "sha512-UHuOBZ5jjsKuzbB/gRNNW8Vg8f00Emgskdq2kvZxgBJCS0aqquAuXai/SkWORlKeZEiNQWZjFZOqIUcH9LqKCw==",
       "dev": true
     },
     "map-age-cleaner": {
@@ -1912,14 +1907,11 @@
         "path-to-regexp": "^1.7.0"
       },
       "dependencies": {
-        "@sinonjs/formatio": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
-          "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/samsam": "^2 || ^3"
-          }
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
         }
       }
     },
@@ -3339,12 +3331,6 @@
         "ret": "~0.1.10"
       }
     },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
-      "dev": true
-    },
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -3401,18 +3387,29 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
-      "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
+      "integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "diff": "^3.1.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.2.0",
-        "nise": "^1.2.0",
-        "supports-color": "^5.1.0",
-        "type-detect": "^4.0.5"
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.1",
+        "diff": "^3.5.0",
+        "lolex": "^4.0.1",
+        "nise": "^1.4.10",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "snapdragon": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "mocha": "^6.0.2",
     "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^13.3.0",
-    "sinon": "^4.2.2",
+    "sinon": "^7.3.2",
     "tmp": "0.0.33",
     "tmp-promise": "^1.0.5"
   },

--- a/test/cache_base.js
+++ b/test/cache_base.js
@@ -146,10 +146,10 @@ describe("Cache: Base Class", () => {
             mock.verify();
         });
 
-        it("should process valid transactions with the reliability manager if high reliability mode is on", async () => {
+        it("should process transactions with the reliability manager if high reliability mode is on", async () => {
             const trx = {
                 finalize: () => {},
-                isValid: false
+                isValid: true
             };
 
             const myOpts = Object.assign({}, opts);
@@ -159,18 +159,12 @@ describe("Cache: Base Class", () => {
             await cache.init(myOpts);
             stub = sinon.stub(cache._rm, "processTransaction");
 
-            // invalid transaction, high reliability enabled: should not process
-            await cache.endPutTransaction(trx);
-            assert(stub.notCalled);
-            stub.resetHistory();
-
-            // valid transaction, high reliability enabled: should process
-            trx.isValid = true;
+            // High reliability enabled: should process
             await cache.endPutTransaction(trx);
             assert(stub.calledOnce);
             stub.resetHistory();
 
-            // valid transaction, high reliability disabled: should not process
+            // High reliability disabled: should not process
             myOpts.highReliability = false;
             await cache.endPutTransaction(trx);
             assert(stub.notCalled);

--- a/test/cache_base.js
+++ b/test/cache_base.js
@@ -132,10 +132,8 @@ describe("Cache: Base Class", () => {
     });
 
     describe("endPutTransaction", () => {
-        let stub;
-
         after(() => {
-            stub.resetBehavior();
+            sinon.restore();
         });
 
         it("should call finalize on the transaction", async () => {
@@ -157,7 +155,7 @@ describe("Cache: Base Class", () => {
             myOpts.highReliabilityOptions = { reliabilityThreshold: 2 };
 
             await cache.init(myOpts);
-            stub = sinon.stub(cache._rm, "processTransaction");
+            const stub = sinon.stub(cache._rm, "processTransaction");
 
             // High reliability enabled: should process
             await cache.endPutTransaction(trx);

--- a/test/command_processor.js
+++ b/test/command_processor.js
@@ -2,20 +2,29 @@ require('./test_init');
 
 const assert = require('assert');
 const sinon = require('sinon');
-const { CommandProcessor, CacheBase , PutTransaction } = require('../lib');
+const randomBuffer = require('./test_utils').randomBuffer;
+const consts = require('../lib/constants');
+const { CommandProcessor, CacheBase } = require('../lib');
 
 describe("CommandProcessor", () => {
     describe("PUT Whitelist", () => {
+        const stubs = [];
+
         beforeEach(() => {
             this.cmdProc = new CommandProcessor(new CacheBase());
+        });
+
+        afterEach(() => {
+            stubs.forEach(s => s.restore());
         });
 
         it("should implement PUT when whitelisted", async () => {
             this.cmdProc._whitelistEmpty = false;
             this.cmdProc._putWhitelist = ["127.0.0.1"];
 
-            this.cmdProc._trx = new PutTransaction();
-            this.cmdProc._trx.clientAddress = "127.0.0.1:1234";
+            stubs.push(sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.1:1234"));
+            await this.cmdProc._onTransactionStart(randomBuffer(consts.GUID_SIZE), randomBuffer(consts.HASH_SIZE));
+
             const spy = sinon.spy(this.cmdProc._trx, "getWriteStream");
 
             const p = this.cmdProc._onPut("a", 999);
@@ -28,8 +37,9 @@ describe("CommandProcessor", () => {
             this.cmdProc._whitelistEmpty = false;
             this.cmdProc._putWhitelist = ["127.0.0.6", "127.0.0.3", "127.0.0.1"];
 
-            this.cmdProc._trx = new PutTransaction();
-            this.cmdProc._trx.clientAddress = "127.0.0.1:1234";
+            stubs.push(sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.1:1234"));
+            await this.cmdProc._onTransactionStart(randomBuffer(consts.GUID_SIZE), randomBuffer(consts.HASH_SIZE));
+
             const spy = sinon.spy(this.cmdProc._trx, "getWriteStream");
 
             const p = this.cmdProc._onPut("a", 999);
@@ -42,8 +52,9 @@ describe("CommandProcessor", () => {
             this.cmdProc._whitelistEmpty = true;
             this.cmdProc._putWhitelist = [];
 
-            this.cmdProc._trx = new PutTransaction();
-            this.cmdProc._trx.clientAddress = "127.0.0.1:1234";
+            stubs.push(sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.1:1234"));
+            await this.cmdProc._onTransactionStart(randomBuffer(consts.GUID_SIZE), randomBuffer(consts.HASH_SIZE));
+
             const spy = sinon.spy(this.cmdProc._trx, "getWriteStream");
 
             const p = this.cmdProc._onPut("a", 999);
@@ -52,17 +63,52 @@ describe("CommandProcessor", () => {
             assert(spy.called);
         });
 
-        it("should allow commands after writing when being whitelisted", async () => {
+        it("should not ask the cache for a writeStream when not whitelisted", async () => {
             this.cmdProc._whitelistEmpty = false;
             this.cmdProc._putWhitelist = ["127.0.0.1"];
 
-            this.cmdProc._trx = new PutTransaction();
-            this.cmdProc._trx.clientAddress = "127.0.0.2:1234";
+            stubs.push(sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.2:1234"));
+            await this.cmdProc._onTransactionStart(randomBuffer(consts.GUID_SIZE), randomBuffer(consts.HASH_SIZE));
+
+            const spy = sinon.spy(this.cmdProc._trx, "getWriteStream");
+
+            const p = this.cmdProc._onPut("a", 999);
+            p.catch(function () {});
+
+            assert(spy.notCalled);
+        });
+
+        it("should allow commands after writing when not whitelisted", async () => {
+            this.cmdProc._whitelistEmpty = false;
+            this.cmdProc._putWhitelist = ["127.0.0.1"];
+
+            stubs.push(sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.2:1234"));
+            await this.cmdProc._onTransactionStart(randomBuffer(consts.GUID_SIZE), randomBuffer(consts.HASH_SIZE));
 
             await this.cmdProc._onPut("a", 6);
             assert.strictEqual(this.cmdProc._writeHandler, this.cmdProc._writeHandlers.putStream);
             this.cmdProc._writeHandler('abcdef');
             assert(this.cmdProc._writeHandlers.command);
+        });
+
+        it("should NOT invalidate a transaction when whitelisted", async () => {
+            this.cmdProc._whitelistEmpty = false;
+            this.cmdProc._putWhitelist = ["127.0.0.1"];
+
+            stubs.push(sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.1:1234"));
+            await this.cmdProc._onTransactionStart(randomBuffer(consts.GUID_SIZE), randomBuffer(consts.HASH_SIZE));
+
+            assert.ok(this.cmdProc._trx.isValid, "Expected transaction to be valid");
+        });
+
+        it("should invalidate a transaction when not whitelisted", async () => {
+            this.cmdProc._whitelistEmpty = false;
+            this.cmdProc._putWhitelist = ["127.0.0.1"];
+
+            stubs.push(sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.2:1234"));
+            await this.cmdProc._onTransactionStart(randomBuffer(consts.GUID_SIZE), randomBuffer(consts.HASH_SIZE));
+
+            assert.ok(!this.cmdProc._trx.isValid, "Expected transaction to be invalid");
         });
     });
 });

--- a/test/command_processor.js
+++ b/test/command_processor.js
@@ -8,27 +8,26 @@ const { CommandProcessor, CacheBase } = require('../lib');
 
 describe("CommandProcessor", () => {
     describe("PUT Whitelist", () => {
-        const stubs = [];
 
         beforeEach(() => {
             this.cmdProc = new CommandProcessor(new CacheBase());
         });
 
         afterEach(() => {
-            stubs.forEach(s => s.restore());
+            sinon.restore();
         });
 
         it("should implement PUT when whitelisted", async () => {
             this.cmdProc._whitelistEmpty = false;
             this.cmdProc._putWhitelist = ["127.0.0.1"];
 
-            stubs.push(sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.1:1234"));
+            sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.1:1234");
             await this.cmdProc._onTransactionStart(randomBuffer(consts.GUID_SIZE), randomBuffer(consts.HASH_SIZE));
 
             const spy = sinon.spy(this.cmdProc._trx, "getWriteStream");
 
             const p = this.cmdProc._onPut("a", 999);
-            p.catch(function () {});
+            p.catch(() => assert.fail());
 
             assert(spy.called);
         });
@@ -37,13 +36,13 @@ describe("CommandProcessor", () => {
             this.cmdProc._whitelistEmpty = false;
             this.cmdProc._putWhitelist = ["127.0.0.6", "127.0.0.3", "127.0.0.1"];
 
-            stubs.push(sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.1:1234"));
+            sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.1:1234");
             await this.cmdProc._onTransactionStart(randomBuffer(consts.GUID_SIZE), randomBuffer(consts.HASH_SIZE));
 
             const spy = sinon.spy(this.cmdProc._trx, "getWriteStream");
 
             const p = this.cmdProc._onPut("a", 999);
-            p.catch(function () {});
+            p.catch(() => assert.fail());
 
             assert(spy.called);
         });
@@ -52,13 +51,13 @@ describe("CommandProcessor", () => {
             this.cmdProc._whitelistEmpty = true;
             this.cmdProc._putWhitelist = [];
 
-            stubs.push(sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.1:1234"));
+            sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.1:1234");
             await this.cmdProc._onTransactionStart(randomBuffer(consts.GUID_SIZE), randomBuffer(consts.HASH_SIZE));
 
             const spy = sinon.spy(this.cmdProc._trx, "getWriteStream");
 
             const p = this.cmdProc._onPut("a", 999);
-            p.catch(function () {});
+            p.catch(() => assert.fail());
 
             assert(spy.called);
         });
@@ -67,13 +66,13 @@ describe("CommandProcessor", () => {
             this.cmdProc._whitelistEmpty = false;
             this.cmdProc._putWhitelist = ["127.0.0.1"];
 
-            stubs.push(sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.2:1234"));
+            sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.2:1234");
             await this.cmdProc._onTransactionStart(randomBuffer(consts.GUID_SIZE), randomBuffer(consts.HASH_SIZE));
 
             const spy = sinon.spy(this.cmdProc._trx, "getWriteStream");
 
             const p = this.cmdProc._onPut("a", 999);
-            p.catch(function () {});
+            p.catch(() => assert.fail());
 
             assert(spy.notCalled);
         });
@@ -82,7 +81,7 @@ describe("CommandProcessor", () => {
             this.cmdProc._whitelistEmpty = false;
             this.cmdProc._putWhitelist = ["127.0.0.1"];
 
-            stubs.push(sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.2:1234"));
+            sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.2:1234");
             await this.cmdProc._onTransactionStart(randomBuffer(consts.GUID_SIZE), randomBuffer(consts.HASH_SIZE));
 
             await this.cmdProc._onPut("a", 6);
@@ -95,7 +94,7 @@ describe("CommandProcessor", () => {
             this.cmdProc._whitelistEmpty = false;
             this.cmdProc._putWhitelist = ["127.0.0.1"];
 
-            stubs.push(sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.1:1234"));
+            sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.1:1234");
             await this.cmdProc._onTransactionStart(randomBuffer(consts.GUID_SIZE), randomBuffer(consts.HASH_SIZE));
 
             assert.ok(this.cmdProc._trx.isValid, "Expected transaction to be valid");
@@ -105,7 +104,7 @@ describe("CommandProcessor", () => {
             this.cmdProc._whitelistEmpty = false;
             this.cmdProc._putWhitelist = ["127.0.0.1"];
 
-            stubs.push(sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.2:1234"));
+            sinon.stub(this.cmdProc, "clientAddress").get(() => "127.0.0.2:1234");
             await this.cmdProc._onTransactionStart(randomBuffer(consts.GUID_SIZE), randomBuffer(consts.HASH_SIZE));
 
             assert.ok(!this.cmdProc._trx.isValid, "Expected transaction to be invalid");

--- a/test/protocol.js
+++ b/test/protocol.js
@@ -230,7 +230,6 @@ describe("Protocol", () => {
                 });
 
                 beforeEach(async () => {
-                    this.stubs = [];
                     client = await getClientPromise(server.port);
 
                     // The Unity client always sends the version once on-connect. i.e., the version should not be pre-pended
@@ -239,7 +238,7 @@ describe("Protocol", () => {
                 });
 
                 afterEach(() => {
-                    this.stubs.forEach(s => s.restore());
+                    sinon.restore();
                     client.destroy();
                 });
 
@@ -316,7 +315,7 @@ describe("Protocol", () => {
                         done();
                     });
 
-                    self.stubs.push(sinon.stub(cache, "getFileStream").rejects());
+                    sinon.stub(cache, "getFileStream").rejects();
 
                     const buf = Buffer.from(encodeCommand(cmd.getAsset, self.data.guid, self.data.hash), 'ascii');
                     clientWrite(client, buf);

--- a/test/unity_cache_server.js
+++ b/test/unity_cache_server.js
@@ -144,7 +144,7 @@ describe("Unity Cache Server bootstrap", () => {
                     verified = true;
             });
 
-            const argv = process.argv.concat(['--dump-config']);
+            const argv = process.argv.slice(0, 2).concat(['--dump-config']);
             UnityCacheServer.handleCommandLine(cmd, this.opts, argv);
             assert.ok(verified);
         });


### PR DESCRIPTION
- Moved whitelist check from _onPut to _onBeginTransaction, Invalidating transactions from IPs that are not whitelisted as soon as they are created
- Have CacheBase process all transactions through the ReliabilityManager when enabled
- Ensure ReliabilityManager does not process invalid transactions