### PR TITLE
[pr] Bugfix/send file queue fix

### DIFF
--- a/lib/server/command_processor.js
+++ b/lib/server/command_processor.js
@@ -83,6 +83,11 @@ class CommandProcessor extends Duplex {
         return this._clientAddress;
     }
 
+    get _sendFileQueueLength() {
+        const q = this[kSendFileQueue];
+        return q ? q.length - this._sendFileQueueIndex : 0;
+    }
+
     _registerEventListeners() {
         this.once('finish', this._printReadStats);
         this.on('pipe', src => {
@@ -92,7 +97,7 @@ class CommandProcessor extends Duplex {
 
         this.on('unpipe', () => {
             this[kSource] = null;
-            this[kSendFileQueue] = [];
+            this[kSendFileQueue] = null;
             this._writeHandler = this._writeHandlers.none;
 
             if(this[kReadStream]) {
@@ -166,15 +171,14 @@ class CommandProcessor extends Duplex {
         }
 
         // No more files to send
-        const qLen = this[kSendFileQueue].length;
-        if(qLen === 0 || this._sendFileQueueIndex >= qLen) {
+        if(this._sendFileQueueLength === 0) {
             return;
         }
 
         // De-queue the next file
-        const file = this[kSendFileQueue][this._sendFileQueueIndex];
-        delete this[kSendFileQueue][this._sendFileQueueIndex];
-        this._sendFileQueueIndex++;
+        const i = this._sendFileQueueIndex++;
+        const file = this[kSendFileQueue][i];
+        delete this[kSendFileQueue][i];
 
         // Respond with file-not-found header and early out, wait for next _read
         if(!file.exists) {
@@ -346,7 +350,7 @@ class CommandProcessor extends Duplex {
         }
         finally {
             this[kSendFileQueue].push(item);
-            if(this[kSendFileQueue].length === 1) {
+            if(this._sendFileQueueLength === 1) {
                 this._read();
             }
         }

--- a/test/protocol.js
+++ b/test/protocol.js
@@ -307,7 +307,8 @@ describe("Protocol", () => {
                     // execute each command in series, asynchronously, to better simulate a real world server connection
                     let next = Promise.resolve();
                     cmdData.forEach(b => {
-                        next = next.then(() => clientWrite(client, Buffer.from(b, 'ascii'), LARGE_PACKET_SIZE));
+                        next = next.then(() => clientWrite(client, Buffer.from(b, 'ascii'), LARGE_PACKET_SIZE))
+                            .catch(err => done(err));
                     });
                 });
 

--- a/test/protocol.js
+++ b/test/protocol.js
@@ -278,7 +278,37 @@ describe("Protocol", () => {
                     // of a stuck async loop
                 });
 
-                it('should retrieve stored versions in the order they were are requested', function(done) {
+                it('should retrieve stored versions in the order they were are requested (queued)', function(done) {
+                    const resp = new CacheServerResponseTransform();
+                    client.pipe(resp);
+
+                    const cmds = ['+a', '+i', '-r', '+i', '+a'];
+
+                    resp.on('data', () => {});
+                    resp.on('dataEnd', () => {
+                        if(cmds.length === 0) {
+                            done();
+                        }
+                    });
+
+                    resp.on('header', header => {
+                        const nextCmd = cmds.shift();
+                        assert.strictEqual(header.cmd, nextCmd);
+                    });
+
+                    const buf = Buffer.from(
+                        encodeCommand(cmd.getAsset, self.data.guid, self.data.hash) +
+                        encodeCommand(cmd.getInfo, self.data.guid, self.data.hash) +
+                        encodeCommand(cmd.getResource, self.data.guid, Buffer.alloc(consts.HASH_SIZE, 'ascii')) +
+                        encodeCommand(cmd.getInfo, self.data.guid, self.data.hash) +
+                        encodeCommand(cmd.getAsset, self.data.guid, self.data.hash), 'ascii');
+
+
+                    // execute all commands in the same frame to simulate filling the send queue in CommandProcessor
+                    clientWrite(client, buf, LARGE_PACKET_SIZE).catch(err => done(err));
+                });
+
+                it('should retrieve stored versions in the order they were are requested (async series)', function(done) {
                     const resp = new CacheServerResponseTransform();
                     client.pipe(resp);
 
@@ -307,7 +337,7 @@ describe("Protocol", () => {
                     // execute each command in series, asynchronously, to better simulate a real world server connection
                     let next = Promise.resolve();
                     cmdData.forEach(b => {
-                        next = next.then(() => clientWrite(client, Buffer.from(b, 'ascii'), LARGE_PACKET_SIZE))
+                        next = next.then(() => clientWrite(client, b, LARGE_PACKET_SIZE))
                             .catch(err => done(err));
                     });
                 });

--- a/test/protocol.js
+++ b/test/protocol.js
@@ -286,7 +286,7 @@ describe("Protocol", () => {
 
                     resp.on('data', () => {});
                     resp.on('dataEnd', () => {
-                        if (cmds.length === 0) {
+                        if(cmds.length === 0) {
                             done();
                         }
                     });


### PR DESCRIPTION
Fix for bugs #126 and #127. After refactoring to change the sendFileQueue from using array push/shift to instead using a fixed array with an index pointer, the queue length was not being calculated correctly, resulting in stalled reads and an out of sync queue index.

The test that should have caught this was updated to fail with the bug, and now passes with the fix.