### PR TITLE
Fixes for client stream recorder tests

### DIFF
--- a/lib/server/client_stream_recorder.js
+++ b/lib/server/client_stream_recorder.js
@@ -79,6 +79,8 @@ class ClientStreamRecorder extends Writable {
     }
 
     async _flush_buffer() {
+        if(this._bufferPos === 0) return;
+
         await fs.ensureDir(this._saveDir);
 
         // Normalize the version size so it will be correctly parsed when streamed to a server.

--- a/test/unity_cache_server.js
+++ b/test/unity_cache_server.js
@@ -213,7 +213,8 @@ describe("Unity Cache Server bootstrap", () => {
                     }
                 },
                 Diagnostics: {
-                    clientRecorder: true
+                    clientRecorder: true,
+                    saveDir: tmpPath
 				}
             });
 


### PR DESCRIPTION
- Fix client recorder and tests to not pollute the working directory
- Don't write zero-byte diagnostic files