### PR TITLE
change shorthand command line option to specify host from -h to -H

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,7 +27,7 @@ const optionMap = {
         configKey: consts.CLI_CONFIG_KEYS.CACHE_PATH
     },
     host: {
-        flags: "-h, --host <address>",
+        flags: "-H, --host <address>",
         description: "The interface on which the Cache Server listens. The default is to listen on all interfaces.",
         configKey: consts.CLI_CONFIG_KEYS.HOST
     },


### PR DESCRIPTION
* A minor bug fix:
* This is to avoid name clash with the shorthand command line option for help -h

**Actual Behavior**
![ActualBehavior](https://user-images.githubusercontent.com/6732525/73580492-95308b80-443a-11ea-9775-fa057c628897.gif)


**Expected Behavior**
![bugfixhelpoption](https://user-images.githubusercontent.com/6732525/73580488-91046e00-443a-11ea-9f99-6371f560c8b3.PNG)

