### PR TITLE
Print errors before exit with 1

### DIFF
--- a/main.js
+++ b/main.js
@@ -65,4 +65,4 @@ const optionMap = {
 // Initialize CLI handler
 cmd.description(description).version(version).allowUnknownOption(true);
 UnityCacheServer.handleCommandLine(cmd, optionMap);
-UnityCacheServer.start().then(() => {}, () => process.exit(1));
+UnityCacheServer.start().then(() => {}, (e) => { console.error(e); process.exit(1) });


### PR DESCRIPTION
This patch makes errors visible to make debugging efficient. Before this patch, `npm start` did not print any errors, so it was hard to debug.


### Before
```console
$ npm start
Cache path is /path/to/node_modules/unity-cache-server/.cache_fs

$ echo $?
1
```

### After

```console
$ npm start
Cache path is /path/to/node_modules/unity-cache-server/.cache_fs
[Error: EACCES: permission denied, mkdir /path/to/node_modules/unity-cache-server/.cache_fs'] {
  errno: -13,
  code: 'EACCES',
  syscall: 'mkdir',
  path: '/path/to/node_modules/unity-cache-server/.cache_fs'
}

$ echo $?
1
```